### PR TITLE
Dockerfiles for RFdiffusion on ROCm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,13 @@
-*.py[cod]
+**/*.git/
+.github/
+docker/
+img/
+examples/ppi_scaffolds/
+
+**/*.py[cod]
 rfdiffusion.egg-info
 __pycache__/
 
-models/
 schedules/
 outputs/
 test_outputs/

--- a/docker/Dockerfile.rocm-complete
+++ b/docker/Dockerfile.rocm-complete
@@ -1,0 +1,28 @@
+# A Docker image for running RFDiffusion using DGL on ROCm. Includes a slightly
+# patched RFDiffusion itself.
+
+FROM gcmn/rfdiffusion:rocm-deps-only
+
+# Install RFDiffusion from local directory
+ARG RFDIFFUSION_HOME="/root/RFdiffusion"
+ENV RFDIFFUSION_HOME="${RFDIFFUSION_HOME}"
+COPY . "${RFDIFFUSION_HOME}"
+WORKDIR "${RFDIFFUSION_HOME}"
+RUN cd env/SE3Transformer \
+    && python setup.py develop \
+    && cd ../.. \
+    && pip install -e .
+
+
+ADD --link http://files.ipd.uw.edu/pub/RFdiffusion/6f5902ac237024bdd0c176cb93063dc4/Base_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/e29311f6f1bf1af907f9ef9f44b8328b/Complex_base_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/60f09a193fb5e5ccdc4980417708dbab/Complex_Fold_base_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/74f51cfb8b440f50d70878e05361d8f0/InpaintSeq_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/76d00716416567174cdb7ca96e208296/InpaintSeq_Fold_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/5532d2e1f3a4738decd58b19d633b3c3/ActiveSite_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/12fc204edeae5b57713c5ad7dcb97d39/Base_epoch8_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/f572d396fae9206628714fb2ce00f72e/Complex_beta_ckpt.pt \
+    http://files.ipd.uw.edu/pub/RFdiffusion/1befcb9b28e2f778f53d47f18b7597fa/RF_structure_prediction_weights.pt \
+    models/
+
+ADD --link examples/ppi_scaffolds_subset.tar.gz examples/

--- a/docker/Dockerfile.rocm-deps-only
+++ b/docker/Dockerfile.rocm-deps-only
@@ -1,0 +1,14 @@
+# A Docker image for running RFDiffusion using DGL on ROCm. Does not include
+# RFdiffusion itself. You can mount a docker volume into the container with the
+# RFdiffusion source.
+
+FROM gcmn/dgl:rocm-complete
+
+WORKDIR /pip
+# RFdiffusion deps
+RUN pip install hydra-core pyrsistent e3nn==0.3.3 decorator==5.1.0 \
+    && rm -rf /pip
+
+ENV PYTHONWARNINGS="ignore::UserWarning,ignore::DeprecationWarning,ignore::PendingDeprecationWarning,ignore::ImportWarning,ignore::ResourceWarning,ignore::FutureWarning"
+
+WORKDIR /


### PR DESCRIPTION
Includes one image that has only the dependencies (including DGL) and one that also has RFdiffusion itself, copied from the local directory. As with https://github.com/nod-ai/dgl/commit/a2c0a9048e, I did a development install of RFdiffusion, so it should be relatively easy to swap in one's own local git repo with a bind mount.