### PR TITLE
Rework golden testing

### DIFF
--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -748,7 +748,7 @@ class ScaffoldedSampler(SelfConditioning):
         else:
             # initialize BlockAdjacency sampling class
             assert all(x is None for x in (conf.contigmap.inpaint_str_helix, conf.contigmap.inpaint_str_strand, conf.contigmap.inpaint_str_loop)), "can't provide scaffold_dir if you're also specifying per-residue ss"
-            self.blockadjacency = iu.BlockAdjacency(conf.scaffoldguided, conf.inference.num_designs)
+            self.blockadjacency = iu.BlockAdjacency(conf)
 
 
         #################################################

--- a/rfdiffusion/inference/utils.py
+++ b/rfdiffusion/inference/utils.py
@@ -681,7 +681,7 @@ class BlockAdjacency:
         - adj: block adjacency with equivalent masking as ss (L,L)
     """
 
-    def __init__(self, conf, num_designs):
+    def __init__(self, conf):
         """
         Parameters:
           inputs:
@@ -692,8 +692,8 @@ class BlockAdjacency:
         self.conf=conf
         # either list or path to .txt file with list of scaffolds
         if self.conf.scaffoldguided.scaffold_list is not None:
-            if type(self.conf.scaffoldguided.scaffold_list) == list:
-                self.scaffold_list = scaffold_list
+            if isinstance(self.conf.scaffoldguided.scaffold_list, list):
+                self.scaffold_list = self.conf.scaffoldguided.scaffold_list
             elif self.conf.scaffoldguided.scaffold_list[-4:] == ".txt":
                 # txt file with list of ids
                 list_from_file = []
@@ -702,7 +702,7 @@ class BlockAdjacency:
                         list_from_file.append(line.strip())
                 self.scaffold_list = list_from_file
             else:
-                raise NotImplementedError
+                raise NotImplementedError()
         else:
             self.scaffold_list = [
                 os.path.split(i)[1][:-6]
@@ -746,7 +746,7 @@ class BlockAdjacency:
         # whether or not to work systematically through the list
         self.systematic = self.conf.scaffoldguided.systematic
 
-        self.num_designs = num_designs
+        self.num_designs = conf.inference.num_designs
 
         if len(self.scaffold_list) > self.num_designs:
             print(

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -30,6 +30,9 @@ import glob
 
 
 def make_deterministic(seed=0):
+    print(f"WARNING: making deterministic with seed {seed}. Determinsitc algorithms may affect performance")
+    # Consider controlling this with a different flag so we can set a seed without a perf hit.
+    torch.use_deterministic_algorithms(True)
     torch.manual_seed(seed)
     np.random.seed(seed)
     random.seed(seed)

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -30,7 +30,7 @@ import glob
 
 
 def make_deterministic(seed=0):
-    print(f"WARNING: making deterministic with seed {seed}. Determinsitc algorithms may affect performance")
+    print(f"WARNING: making deterministic with seed {seed}. Deterministic algorithms may affect performance")
     # Consider controlling this with a different flag so we can set a seed without a perf hit.
     torch.use_deterministic_algorithms(True)
     torch.manual_seed(seed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--update-goldens", action="store_true", help="Update golden reference output files")

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -1,265 +1,112 @@
-import unittest
-import subprocess
-import glob
 import datetime
-import os
-import torch
-from shutil import copyfile
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
 from rfdiffusion.inference import utils as iu
 from rfdiffusion.util import calc_rmsd
-import sys, json
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-
-class TestSubmissionCommands(unittest.TestCase):
-    """
-    Test harness for checking that commands in the examples folder,
-    when run in deterministic mode, produce the same output as the
-    reference outputs.
-    Requirements:
-        - example command must be written on a single line
-        - outputs must be written to example_outputs folder
-        - needs to be run on the same hardware as the reference outputs (A100 GPU)
-    For speed, we only run the first 2 steps of diffusion, and set inference.num_designs=1
-    This means that outputs DO NOT look like proteins, but we can still check that the
-    outputs are the same as the reference outputs.
-    """
-
-    def setUp(self):
-        """
-        Grabs files from the examples folder
-        """
-        submissions = glob.glob(f"{script_dir}/../examples/*.sh")
-        # get datetime for output folder, in YYYY_MM_DD_HH_MM_SS format
-        now = datetime.datetime.now()
-        now = now.strftime("%Y_%m_%d_%H_%M_%S")
-        self.out_f = f"{script_dir}/tests_{now}"
-        os.mkdir(self.out_f)
-
-        # Make sure we have access to all the relevant files
-        exclude_dirs = ["outputs", "example_outputs"]
-        for filename in os.listdir(f"{script_dir}/../examples"):
-            if filename not in exclude_dirs and not os.path.islink(os.path.join(script_dir, filename)) and os.path.isdir(os.path.join(f'{script_dir}/../examples', filename)):
-                os.symlink(os.path.join(f'{script_dir}/../examples', filename), os.path.join(script_dir, filename))
-
-        for submission in submissions:
-            self._write_command(submission, self.out_f)
-
-        print(f"Running commands in {self.out_f}, two steps of diffusion, deterministic=True")
-
-        self.results = {}
-
-        for bash_file in sorted( glob.glob(f"{self.out_f}/*.sh"), reverse=False):
-            test_name = os.path.basename(bash_file)[:-len('.sh')]
-            res, output = execute(f"Running {test_name}", f'bash {bash_file}', return_='tuple', add_message_and_command_line_to_output=True)
-
-            self.results[test_name] = dict(
-                state = 'failed' if res else 'passed',
-                log = output,
-            )
-
-            #subprocess.run(["bash", bash_file], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            #subprocess.run(["bash", bash_file])
+script_dir = pathlib.Path(__file__).parent
+example_dir = script_dir.parent / "examples"
 
 
-    def test_commands(self):
-        """
-        Runs all the commands in the test_f folder
-        """
-        reference=f'{script_dir}/reference_outputs'
-        os.makedirs(reference, exist_ok=True)
-        test_files=glob.glob(f"{self.out_f}/example_outputs/*pdb")
-        print(f'{self.out_f=} {test_files=}')
-
-        # first check that we have the right number of outputs
-        #self.assertEqual(len(test_files), len(glob.glob(f"{self.out_f}/*.sh"))), "One or more of the example commands didn't produce an output (check the example command is formatted correctly)"
-
-        result = self.defaultTestResult()
-        for test_file in test_files:
-            with self.subTest(test_file=test_file):
-                test_pdb=iu.parse_pdb(test_file)
-                if not os.path.exists(f"{reference}/{os.path.basename(test_file)}"):
-                    copyfile(test_file, f"{reference}/{os.path.basename(test_file)}")
-                    print(f"Created reference file {reference}/{os.path.basename(test_file)}")
-                else:
-                    ref_pdb=iu.parse_pdb(f"{reference}/{os.path.basename(test_file)}")
-                    rmsd=calc_rmsd(test_pdb['xyz'][:,:3].reshape(-1,3), ref_pdb['xyz'][:,:3].reshape(-1,3))[0]
-                    try:
-                        self.assertAlmostEqual(rmsd, 0, 2)
-                        result.addSuccess(self)
-                        print(f"Subtest {test_file} passed")
-
-                        state = 'passed'
-                        log = f'Subtest {test_file} passed'
-
-                    except AssertionError as e:
-                        result.addFailure(self, e)
-                        print(f"Subtest {test_file} failed")
-
-                        state = 'failed'
-                        log = f'Subtest {test_file} failed:\n{e!r}'
-
-                    self.results[ 'pdb-diff.' + test_file.rpartition('/')[-1] ] = dict(state = state, log = log)
-
-        with open('.results.json', 'w') as f: json.dump(self.results, f, sort_keys=True, indent=2)
-
-        self.assertTrue(result.wasSuccessful(), "One or more subtests failed")
+@pytest.fixture(scope="module")
+def output_dir():
+    now = datetime.datetime.now()
+    now = now.strftime("%Y_%m_%d_%H_%M_%S")
+    d = script_dir / f"tests_{now}"
+    d.mkdir()
+    return d
 
 
-    def _write_command(self, bash_file, test_f) -> None:
-        """
-        Takes a bash file from the examples folder, and writes
-        a version of it to the test_f folder.
-        It appends to the python command the following arguments:
-            inference.deterministic=True
-            if partial_T is in the command, it grabs partial T and sets:
-                inference.final_step=partial_T-2
-            else:
-                inference.final_step=48
-        """
-        out_lines=[]
-        with open(bash_file, "r") as f:
-            lines = f.readlines()
-            for line in lines:
-                if not (line.startswith("python") or line.startswith("../")):
-                    out_lines.append(line)
-                else:
-                    command = line.strip()
-            if not command.startswith("python"):
-                command = f'python {command}'
-        # get the partial_T
-        if "partial_T" in command:
-            final_step = int(command.split("partial_T=")[1].split(" ")[0]) - 2
-        else:
-            final_step = 48
-
-        output_command = f"{command} inference.deterministic=True inference.final_step={final_step}"
-        # replace inference.num_designs with 1
-        if "inference.num_designs=" in output_command:
-            output_command = f'{output_command.split("inference.num_designs=")[0]}inference.num_designs=1 {" ".join(output_command.split("inference.num_designs=")[1].split(" ")[1:])}'
-        else:
-            output_command = f'{output_command} inference.num_designs=1'
-        # replace 'example_outputs' with f'{self.out_f}/example_outputs'
-        output_command = f'{output_command.split("example_outputs")[0]}{self.out_f}/example_outputs{output_command.split("example_outputs")[1]}'
+@pytest.fixture(scope="module")
+def reference_dir():
+    d = script_dir / "reference_outputs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
-        # write the new command
-        with open(f"{test_f}/{os.path.basename(bash_file)}", "w") as f:
-            for line in out_lines:
-                f.write(line)
-            f.write(output_command)
+@pytest.fixture(scope="module")
+def symlink_inputs():
+    # Make sure we have access to all the relevant files
+    exclude_dirs = ["outputs", "example_outputs"]
+    for p in example_dir.iterdir():
+        link = script_dir / p.name
+        if p.name not in exclude_dirs and p.is_dir() and not link.is_symlink():
+            print(f"Symlinking {link} -> {p}")
+            link.symlink_to(p)
 
 
+@pytest.fixture(
+    scope="module", params=sorted(example_dir.glob("*.sh")), ids=lambda x: x.stem
+)
+def modified_script(request, output_dir):
+    return _write_command(request.param, output_dir)
 
-def execute_through_pty(command_line):
-    import pty, select
 
-    if sys.platform == "darwin":
-
-        master, slave = pty.openpty()
-        p = subprocess.Popen(command_line, shell=True, stdout=slave, stdin=slave,
-                             stderr=subprocess.STDOUT, close_fds=True)
-
-        buffer = []
-        while True:
-            try:
-                if select.select([master], [], [], 0.2)[0]:  # has something to read
-                    data = os.read(master, 1 << 22)
-                    if data: buffer.append(data)
-
-                elif (p.poll() is not None)  and  (not select.select([master], [], [], 0.2)[0] ): break  # process is finished and output buffer if fully read
-
-            except OSError: break  # OSError will be raised when child process close PTY descriptior
-
-        output = b''.join(buffer).decode(encoding='utf-8', errors='backslashreplace')
-
-        os.close(master)
-        os.close(slave)
-
-        p.wait()
-        exit_code = p.returncode
-
-        '''
-        buffer = []
-        while True:
-            if select.select([master], [], [], 0.2)[0]:  # has something to read
-                data = os.read(master, 1 << 22)
-                if data: buffer.append(data)
-                # else: break  # # EOF - well, technically process _should_ be finished here...
-
-            # elif time.sleep(1) or (p.poll() is not None): # process is finished (sleep here is intentional to trigger race condition, see solution for this on the next few lines)
-            #     assert not select.select([master], [], [], 0.2)[0]  # should be nothing left to read...
-            #     break
-
-            elif (p.poll() is not None)  and  (not select.select([master], [], [], 0.2)[0] ): break  # process is finished and output buffer if fully read
-
-        assert not select.select([master], [], [], 0.2)[0]  # should be nothing left to read...
-
-        os.close(slave)
-        os.close(master)
-
-        output = b''.join(buffer).decode(encoding='utf-8', errors='backslashreplace')
-        exit_code = p.returncode
-        '''
-
+def test_command(modified_script, output_dir, reference_dir, symlink_inputs, request):
+    print(f"Running {modified_script}")
+    subprocess.run(["bash", modified_script], check=True)
+    test_name = modified_script.stem
+    test_files = list((output_dir / "example_outputs" / test_name).glob("*.pdb"))
+    assert len(test_files) == 1
+    test_file = test_files[0]
+    test_pdb = iu.parse_pdb(test_file)
+    reference_file = reference_dir / test_file.relative_to(output_dir)
+    if request.config.getoption("--update-goldens"):
+        reference_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(test_file, reference_file)
+        print(f"Updated reference file {reference_file}")
     else:
-
-        master, slave = pty.openpty()
-        p = subprocess.Popen(command_line, shell=True, stdout=slave, stdin=slave,
-                             stderr=subprocess.STDOUT, close_fds=True)
-
-        os.close(slave)
-
-        buffer = []
-        while True:
-            try:
-                data = os.read(master, 1 << 22)
-                if data: buffer.append(data)
-            except OSError: break  # OSError will be raised when child process close PTY descriptior
-
-        output = b''.join(buffer).decode(encoding='utf-8', errors='backslashreplace')
-
-        os.close(master)
-
-        p.wait()
-        exit_code = p.returncode
-
-    return exit_code, output
+        ref_pdb = iu.parse_pdb(reference_file)
+        rmsd = calc_rmsd(
+            test_pdb["xyz"][:, :3].reshape(-1, 3), ref_pdb["xyz"][:, :3].reshape(-1, 3)
+        )[0]
+        assert rmsd == pytest.approx(0, rel=0, abs=0.01)
 
 
-
-def execute(message, command_line, return_='status', until_successes=False, terminate_on_failure=True, silent=False, silence_output=False, silence_output_on_errors=False, add_message_and_command_line_to_output=False):
-    if not silent: print(message);  print(command_line); sys.stdout.flush();
-    while True:
-
-        #exit_code, output = execute_through_subprocess(command_line)
-        #exit_code, output = execute_through_pexpect(command_line)
-        exit_code, output = execute_through_pty(command_line)
-
-        if (exit_code  and  not silence_output_on_errors) or  not (silent or silence_output): print(output); sys.stdout.flush();
-
-        if exit_code and until_successes: pass  # Thats right - redability COUNT!
-        else: break
-
-        print( "Error while executing {}: {}\n".format(message, output) )
-        print("Sleeping 60s... then I will retry...")
-        sys.stdout.flush();
-        time.sleep(60)
-
-    if add_message_and_command_line_to_output: output = message + '\nCommand line: ' + command_line + '\n' + output
-
-    if return_ == 'tuple'  or  return_ == tuple: return(exit_code, output)
-
-    if exit_code and terminate_on_failure:
-        print("\nEncounter error while executing: " + command_line)
-        if return_==True: return True
+def _write_command(bash_file, output_dir):
+    """
+    Takes a bash file from the examples folder, and writes
+    a version of it to the output_dir folder.
+    It appends to the python command the following arguments:
+        inference.deterministic=True
+        if partial_T is in the command, it grabs partial T and sets:
+            inference.final_step=partial_T-2
         else:
-            print('\nEncounter error while executing: ' + command_line + '\n' + output);
-            raise BenchmarkError('\nEncounter error while executing: ' + command_line + '\n' + output)
+            inference.final_step=48
+    """
+    out_lines = []
+    with open(bash_file, "r") as f:
+        lines = f.readlines()
+        for line in lines:
+            if not (line.startswith("python") or line.startswith("../")):
+                out_lines.append(line)
+            else:
+                command = line.strip()
+        if not command.startswith("python"):
+            command = f"python {command}"
+    # get the partial_T
+    if "partial_T" in command:
+        final_step = int(command.split("partial_T=")[1].split(" ")[0]) - 2
+    else:
+        final_step = 48
 
-    if return_ == 'output': return output
-    else: return exit_code
+    test_name = bash_file.stem
+
+    # Override these. It's ok if they're already specified, as last one wins
+    command = f"{command} inference.num_designs=1 inference.output_prefix={output_dir}/example_outputs/{test_name}/{test_name} inference.deterministic=True inference.final_step={final_step}"
+
+    out_lines.append(command)
+
+    # write the new command
+    output_script = output_dir / bash_file.name
+    output_script.write_text(''.join(out_lines))
+
+    return output_script
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main()

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -82,26 +82,28 @@ def _write_command(bash_file, output_dir):
     with open(bash_file, "r") as f:
         lines = f.readlines()
         for line in lines:
-            if not (line.startswith("python") or line.startswith("../")):
-                out_lines.append(line)
+            if line.startswith("python") or line.startswith("../"):
+                command = line.rstrip()
+                if "partial_T" in command:
+                    final_step = int(command.split("partial_T=")[1].split(" ")[0]) - 2
+                else:
+                    final_step = 48
+
+                test_name = bash_file.stem
+
+                # Override these. It's ok if they're already specified, as last one wins
+                command = (
+                    f"{command}"
+                    f" inference.num_designs=1"
+                    f" inference.output_prefix={output_dir}/example_outputs/{test_name}/{test_name}"
+                    f" inference.deterministic=True"
+                    f" inference.final_step={final_step}"
+                )
+
+                out_lines.append(command)
             else:
-                command = line.strip()
-        if not command.startswith("python"):
-            command = f"python {command}"
-    # get the partial_T
-    if "partial_T" in command:
-        final_step = int(command.split("partial_T=")[1].split(" ")[0]) - 2
-    else:
-        final_step = 48
+                out_lines.append(line)
 
-    test_name = bash_file.stem
-
-    # Override these. It's ok if they're already specified, as last one wins
-    command = f"{command} inference.num_designs=1 inference.output_prefix={output_dir}/example_outputs/{test_name}/{test_name} inference.deterministic=True inference.final_step={final_step}"
-
-    out_lines.append(command)
-
-    # write the new command
     output_script = output_dir / bash_file.name
     output_script.write_text(''.join(out_lines))
 


### PR DESCRIPTION
These tests reinvented a lot of existing technology for golden testing. Switched to pytest and cleaned them up using that. In doing so, fixed several tests that were silently failing and added `torch.use_deterministic_algorithms` to the `make_deterministic` option, which was required to get deterministic results on MI210.

Tests now have defined names, can be selected as pytest parametrized tests, can fail fast, can display output or not, etc.

I didn't use either of the existing pytest golden plugins because neither of them actually do what we want here. One requires tests to be specified as yaml files and the other takes over file comparison.

There's still some weird parsing of bash files here, but I decided to not mess with that too much as it appears to work at the moment.

It also still floods you with temporary directories in a way that seems a bit unnecessary and could probably be managed by pytest, but the code has a number of specific dependencies on exactly where a command is run that I didn't want to touch right now.