### PR TITLE
Diffusion regression tests based on hydra config

### DIFF
--- a/tests/configs.yaml
+++ b/tests/configs.yaml
@@ -1,0 +1,16 @@
+tests:
+
+  ##### Unconditional Generation #####
+  - inference:
+      random_seed: 1337
+    contigmap:
+      contigs: ["150-150"]
+    diffuser:
+      T: 15
+
+  - inference:
+      random_seed: 1337
+    contigmap:
+      contigs: ["700-700"]
+    diffuser:
+      T: 15

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -4,13 +4,30 @@ import shutil
 import subprocess
 
 from Bio.PDB import PDBParser, Superimposer
+import hydra
+from omegaconf import OmegaConf
 import numpy as np
 import pytest
+import torch
+import yaml
 
 from rfdiffusion.inference import utils as iu
+from rfdiffusion.inference.run import run_inference
 
 script_dir = pathlib.Path(__file__).parent
 example_dir = script_dir.parent / "examples"
+
+# We have two different ways of splitting up GPUs depending on whether the test
+# is launching a subprocess or running in-process. I tried just setting the
+# torch device number and environment variables together, but this had two problems:
+#   - setting the current device to anything other than 0 initalizes cuda, which
+#     takes a long time. This is pretty wasteful when the process is just going
+#     to launch another script.
+#   - Torch does not behave well if you change CUDA_VISIBLE_DEVICES after it's
+#     imported. Theoretically it's supposed to handle this, but it actually
+#     won't change the current device. It just uses the environment variable to
+#     calculate a new device_count, which means any subsequent attempt to change
+#     the device fails.
 
 
 def partition_gpus(idx, env, env_var):
@@ -30,6 +47,15 @@ def child_env(worker_idx):
     partition_gpus(worker_idx, env, "HIP_VISIBLE_DEVICES")
 
     return env
+
+
+@pytest.fixture(scope="session")
+def set_torch_device(worker_idx):
+    if worker_idx == 0:
+        # these checks are slow. We can skip them in the simple case.
+        return
+    device_count = torch.cuda.device_count()
+    torch.cuda.set_device(worker_idx % device_count)
 
 
 @pytest.fixture(scope="module")
@@ -85,19 +111,7 @@ def calc_backbone_rmsd(ref_pdb, test_pdb):
     return calc_atom_rmsd(get_backbone(ref_pdb), get_backbone(test_pdb))
 
 
-@pytest.mark.usefixtures("symlink_inputs")
-@pytest.mark.parametrize(
-    "script", sorted(example_dir.glob("*.sh")), ids=lambda x: x.stem
-)
-def test_command(script, tmp_path, reference_dir, child_env, request):
-    # The pytest docs say you need to create this directory, but empirically it
-    # is already created.
-    output_dir = tmp_path
-    modified_script = _write_command(script, output_dir)
-    print(f"Running {modified_script}")
-    # cwd is required because the scripts use relative paths like `../scripts/run_inference.py`
-    subprocess.run(["bash", modified_script], check=True, cwd=script_dir, env=child_env)
-    test_name = modified_script.stem
+def handle_test_output(test_name, reference_dir, output_dir, request):
     test_file = output_dir / f"{test_name}_0.pdb"
     reference_file = reference_dir / test_file.relative_to(output_dir)
 
@@ -122,6 +136,21 @@ def test_command(script, tmp_path, reference_dir, child_env, request):
         print(f"RMSD={rmsd:.3}")
 
         assert rmsd == pytest.approx(0, rel=0, abs=0.01)
+
+
+@pytest.mark.usefixtures("symlink_inputs")
+@pytest.mark.parametrize(
+    "script", sorted(example_dir.glob("*.sh")), ids=lambda x: x.stem
+)
+def test_command(script, tmp_path, reference_dir, child_env, request):
+    # The pytest docs say you need to create this directory, but empirically it
+    # is already created.
+    output_dir = tmp_path
+    modified_script = _write_command(script, output_dir)
+    print(f"Running {modified_script}")
+    # cwd is required because the scripts use relative paths like `../scripts/run_inference.py`
+    subprocess.run(["bash", modified_script], check=True, cwd=script_dir, env=child_env)
+    handle_test_output(modified_script.stem, reference_dir, output_dir, request)
 
 
 def _write_command(bash_file, output_dir):
@@ -166,6 +195,72 @@ def _write_command(bash_file, output_dir):
 
     return output_script
 
+
+def flatten_nested_dict(d, parent_key="", sep="."):
+    """Flatten a nested dictionary using dot notation for keys."""
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(flatten_nested_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+def config_id(config):
+    if name := config.pop("name", None):
+        return name
+    flattened = flatten_nested_dict(config)
+
+    if "inference.input_pdb" in flattened:
+        flattened["inference.input_pdb"] = pathlib.Path(
+            flattened["inference.input_pdb"]
+        ).stem
+    if "diffuser.T" in flattened:
+        flattened["diffuser.T"] = f"T{flattened['diffuser.T']}"
+
+    fields = []
+    for v in flattened.values():
+        if isinstance(v, list):
+            fields.append("_".join(v))
+        else:
+            fields.append(str(v))
+
+    return "_".join(fields)
+
+
+@pytest.mark.usefixtures("set_torch_device", "symlink_inputs")
+@pytest.mark.parametrize(
+    "spec",
+    yaml.safe_load((script_dir / "configs.yaml").read_text())["tests"],
+    ids=config_id,
+)
+def test_config(spec, tmp_path, reference_dir, request):
+    os.chdir(script_dir)
+
+    with hydra.initialize(config_path="../config/inference"):
+        conf = hydra.compose(config_name="base")
+        # hydra.compose has an overrides argument but it only accepts
+        # dot-notation string syntax like
+        # "configmap.contigs=[A151-180/70-70/A251-300]" for some reason. It
+        # seems annoying and error-prone to convert our already structured input
+        # into that format (even though I already wrote a flatten function to
+        # construct test ids: that is far more appropriate when a string is the
+        # end goal)
+        output_dir = tmp_path
+        test_name = request.node.callspec.id.replace(" ", "_").replace("/", "_")
+        overrides = {
+            "inference": {
+                "num_designs": 1,
+                "output_prefix": output_dir / test_name,
+                "deterministic": True,
+            }
+        }
+        conf = OmegaConf.merge(conf, spec, overrides)
+
+        run_inference(conf)
+        handle_test_output(test_name, reference_dir, output_dir, request)
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
The existing tests that run the examples have the advantage that they can reuse something that already exists and they ensure the user-facing examples don't break. But for just expanding test coverage, it's a lot nicer and less error prone to write specs directly IMO. I want to use a similar setup for benchmarking as well.