### PR TITLE
Remove direct usage of `opt_einsum`

### DIFF
--- a/rfdiffusion/Attention_module.py
+++ b/rfdiffusion/Attention_module.py
@@ -2,7 +2,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import math
-from opt_einsum import contract as einsum
 from rfdiffusion.util_module import init_lecun_normal
 
 class FeedForwardLayer(nn.Module):
@@ -65,10 +64,10 @@ class Attention(nn.Module):
         value = self.to_v(value).reshape(B, K, self.h, self.dim)
         #
         query = query * self.scaling
-        attn = einsum('bqhd,bkhd->bhqk', query, key)
+        attn = torch.einsum('bqhd,bkhd->bhqk', query, key)
         attn = F.softmax(attn, dim=-1)
         #
-        out = einsum('bhqk,bkhd->bqhd', attn, value)
+        out = torch.einsum('bhqk,bkhd->bqhd', attn, value)
         out = out.reshape(B, Q, self.h*self.dim)
         #
         out = self.to_out(out)
@@ -124,11 +123,11 @@ class AttentionWithBias(nn.Module):
         gate = torch.sigmoid(self.to_g(x))
         #
         key = key * self.scaling
-        attn = einsum('bqhd,bkhd->bqkh', query, key)
+        attn = torch.einsum('bqhd,bkhd->bqkh', query, key)
         attn = attn + bias
         attn = F.softmax(attn, dim=-2)
         #
-        out = einsum('bqkh,bkhd->bqhd', attn, value).reshape(B, L, -1)
+        out = torch.einsum('bqkh,bkhd->bqhd', attn, value).reshape(B, L, -1)
         out = gate * out
         #
         out = self.to_out(out)
@@ -162,7 +161,7 @@ class SequenceWeight(nn.Module):
         k = self.to_key(msa).view(B, N, L, self.h, self.dim)
 
         q = q * self.scale
-        attn = einsum('bqihd,bkihd->bkihq', q, k)
+        attn = torch.einsum('bqihd,bkihd->bkihq', q, k)
         attn = F.softmax(attn, dim=1)
         return self.dropout(attn)
 
@@ -218,11 +217,11 @@ class MSARowAttentionWithBias(nn.Module):
         #
         query = query * seq_weight.expand(-1, -1, -1, -1, self.dim)
         key = key * self.scaling
-        attn = einsum('bsqhd,bskhd->bqkh', query, key)
+        attn = torch.einsum('bsqhd,bskhd->bqkh', query, key)
         attn = attn + bias
         attn = F.softmax(attn, dim=-2)
         #
-        out = einsum('bqkh,bskhd->bsqhd', attn, value).reshape(B, N, L, -1)
+        out = torch.einsum('bskhd,bqkh->bsqhd', value, attn).reshape(B, N, L, -1)
         out = gate * out
         #
         out = self.to_out(out)
@@ -270,10 +269,10 @@ class MSAColAttention(nn.Module):
         gate = torch.sigmoid(self.to_g(msa))
         #
         query = query * self.scaling
-        attn = einsum('bqihd,bkihd->bihqk', query, key)
+        attn = torch.einsum('bqihd,bkihd->bihqk', query, key)
         attn = F.softmax(attn, dim=-1)
         #
-        out = einsum('bihqk,bkihd->bqihd', attn, value).reshape(B, N, L, -1)
+        out = torch.einsum('bihqk,bkihd->bqihd', attn, value).reshape(B, N, L, -1)
         out = gate * out
         #
         out = self.to_out(out)
@@ -322,10 +321,10 @@ class MSAColGlobalAttention(nn.Module):
         gate = torch.sigmoid(self.to_g(msa)) # (B, N, L, h*dim)
         #
         query = query * self.scaling
-        attn = einsum('bihd,bkid->bihk', query, key) # (B, L, h, N)
+        attn = torch.einsum('bihd,bkid->bihk', query, key) # (B, L, h, N)
         attn = F.softmax(attn, dim=-1)
         #
-        out = einsum('bihk,bkid->bihd', attn, value).reshape(B, 1, L, -1) # (B, 1, L, h*dim)
+        out = torch.einsum('bihk,bkid->bihd', attn, value).reshape(B, 1, L, -1) # (B, 1, L, h*dim)
         out = gate * out # (B, N, L, h*dim)
         #
         out = self.to_out(out)
@@ -390,11 +389,11 @@ class BiasedAxialAttention(nn.Module):
 
         query = query * self.scaling
         key = key / math.sqrt(L) # normalize for tied attention
-        attn = einsum('bnihk,bnjhk->bijh', query, key) # tied attention
+        attn = torch.einsum('bnjhk,bnihk->bijh', key, query) # tied attention
         attn = attn + bias # apply bias
         attn = F.softmax(attn, dim=-2) # (B, L, L, h)
 
-        out = einsum('bijh,bkjhd->bikhd', attn, value).reshape(B, L, L, -1)
+        out = torch.einsum('bkjhd,bijh->bikhd', value, attn).reshape(B, L, L, -1)
         out = gate * out
 
         out = self.to_out(out)

--- a/rfdiffusion/Embeddings.py
+++ b/rfdiffusion/Embeddings.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from opt_einsum import contract as einsum
 import torch.utils.checkpoint as checkpoint
 from rfdiffusion.util import get_tips
 from rfdiffusion.util_module import Dropout, create_custom_forward, rbf, init_lecun_normal

--- a/rfdiffusion/RoseTTAFoldModel.py
+++ b/rfdiffusion/RoseTTAFoldModel.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 from rfdiffusion.Embeddings import MSA_emb, Extra_emb, Templ_emb, Recycling
 from rfdiffusion.Track_module import IterativeSimulator
 from rfdiffusion.AuxiliaryPredictor import DistanceNetwork, MaskedTokenNetwork, ExpResolvedNetwork, LDDTNetwork
-from opt_einsum import contract as einsum
 
 class RoseTTAFoldModule(nn.Module):
     def __init__(self,
@@ -105,7 +104,7 @@ class RoseTTAFoldModule(nn.Module):
 
         if return_raw:
             # get last structure
-            xyz = einsum('bnij,bnaj->bnai', R[-1], xyz[:,:,:3]-xyz[:,:,1].unsqueeze(-2)) + T[-1].unsqueeze(-2)
+            xyz = torch.einsum('bnij,bnaj->bnai', R[-1], xyz[:,:,:3]-xyz[:,:,1].unsqueeze(-2)) + T[-1].unsqueeze(-2)
             return msa[:,0], pair, xyz, state, alpha_s[-1]
 
         # predict masked amino acids
@@ -116,7 +115,7 @@ class RoseTTAFoldModule(nn.Module):
 
         if return_infer:
             # get last structure
-            xyz = einsum('bnij,bnaj->bnai', R[-1], xyz[:,:,:3]-xyz[:,:,1].unsqueeze(-2)) + T[-1].unsqueeze(-2)
+            xyz = torch.einsum('bnij,bnaj->bnai', R[-1], xyz[:,:,:3]-xyz[:,:,1].unsqueeze(-2)) + T[-1].unsqueeze(-2)
 
             # get scalar plddt
             nbin = lddt.shape[1]
@@ -135,6 +134,6 @@ class RoseTTAFoldModule(nn.Module):
         logits_exp = self.exp_pred(msa[:,0], state)
 
         # get all intermediate bb structures
-        xyz = einsum('rbnij,bnaj->rbnai', R, xyz[:,:,:3]-xyz[:,:,1].unsqueeze(-2)) + T.unsqueeze(-2)
+        xyz = torch.einsum('rbnij,bnaj->rbnai', R, xyz[:,:,:3]-xyz[:,:,1].unsqueeze(-2)) + T.unsqueeze(-2)
 
         return logits, logits_aa, logits_exp, xyz, alpha_s, lddt

--- a/rfdiffusion/Track_module.py
+++ b/rfdiffusion/Track_module.py
@@ -130,7 +130,7 @@ class MSA2Pair(nn.Module):
         left = self.proj_left(msa)
         right = self.proj_right(msa)
         right = right / float(N)
-        out = einsum('bsli,bsmj->blmij', left, right).reshape(B, L, L, -1)
+        out = torch.einsum('bsli,bsmj->blmij', left, right).reshape(B, L, L, -1)
         out = self.proj_out(out)
 
         pair = pair + out
@@ -287,7 +287,7 @@ class Str2Str(nn.Module):
         delRi[:,:,2,1] = 2*qC*qD + 2*qA*qB
         delRi[:,:,2,2] = qA*qA-qB*qB-qC*qC+qD*qD
 
-        Ri = einsum('bnij,bnjk->bnik', delRi, R_in)
+        Ri = torch.einsum('bnij,bnjk->bnik', delRi, R_in)
         Ti = delTi + T_in #einsum('bnij,bnj->bni', delRi, T_in) + delTi
 
         alpha = self.sc_predictor(msa[:,0], state)
@@ -415,7 +415,7 @@ class IterativeSimulator(nn.Module):
             R_in = R_in.detach() # detach rotation (for stability)
             T_in = T_in.detach()
             # Get current BB structure
-            xyz = einsum('bnij,bnaj->bnai', R_in, xyz_in) + T_in.unsqueeze(-2)
+            xyz = torch.einsum('bnij,bnaj->bnai', R_in, xyz_in) + T_in.unsqueeze(-2)
 
             msa_full, pair, R_in, T_in, state, alpha = self.extra_block[i_m](msa_full,
                                                                              pair,
@@ -434,7 +434,7 @@ class IterativeSimulator(nn.Module):
             R_in = R_in.detach()
             T_in = T_in.detach()
             # Get current BB structure
-            xyz = einsum('bnij,bnaj->bnai', R_in, xyz_in) + T_in.unsqueeze(-2)
+            xyz = torch.einsum('bnij,bnaj->bnai', R_in, xyz_in) + T_in.unsqueeze(-2)
 
             msa, pair, R_in, T_in, state, alpha = self.main_block[i_m](msa,
                                                                        pair,
@@ -453,7 +453,7 @@ class IterativeSimulator(nn.Module):
         for i_m in range(self.n_ref_block):
             R_in = R_in.detach()
             T_in = T_in.detach()
-            xyz = einsum('bnij,bnaj->bnai', R_in, xyz_in) + T_in.unsqueeze(-2)
+            xyz = torch.einsum('bnij,bnaj->bnai', R_in, xyz_in) + T_in.unsqueeze(-2)
             R_in, T_in, state, alpha = self.str_refiner(msa,
                                                         pair,
                                                         R_in,

--- a/rfdiffusion/util_module.py
+++ b/rfdiffusion/util_module.py
@@ -2,7 +2,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from opt_einsum import contract as einsum
 import copy
 import dgl
 from rfdiffusion.util import base_indices, RTs_by_torsion, xyzs_in_base_frame, rigid_from_3_points


### PR DESCRIPTION
Torch already uses this under the hood when you call `torch.einsum`, but better and in a way that's compatible with `torch.compile`.

I swapped the argument order on a couple of einsums in order to preserve bit-exact output. I was getting a discrepancy with the change of these einsums to `torch.compile`. I traced through the code and if `opt_einsum` is installed, `torch.einsum` calls it iff the einsum has more than two inputs (otherwise there's no optimization to be done AFAIU). On the other hand, `opt_einsum` if called directly in this case does a bunch of fiddling around to not optimize the path and then calls `torch.einsum`. Somewhere in that fiddling for some of the einsums, `opt_einsum` seems to swap the order of the operands. So we get differences in the output on the order of `5e-8` and that stacks up into an overall difference in the RMSD for the protein. This also explains why removing `opt_einsum` is in general a performance gain: torch already reaps all the possible performance benefits but does it better. So we can get identical output (at the PDB level) by just swapping the order and calling torch directly.

This also raises the point though that there's nothing really magical about the current numeric output. Either einsum order here is reasonable (and if anything the version that calls `torch.einsum` directly without swapping the args is arguably more correct, as its closer to the programmer intent). It's really nice to have the ability to test and confirm that there's no diff from any given change, but for some more complicated things like `torch.compile` that's going to be quite difficult to guarantee (and severely limits optimization opportunities). The strict RMSD limit is probably something we will want to relax for certain changes, therefore.

Max RMSD diff: 0.0