### PR TITLE
Correct config tests to only run 2 inference steps

### DIFF
--- a/tests/configs.yaml
+++ b/tests/configs.yaml
@@ -3,14 +3,12 @@ tests:
   ##### Unconditional Generation #####
   - inference:
       random_seed: 1337
+      final_step: 48
     contigmap:
       contigs: ["150-150"]
-    diffuser:
-      T: 15
 
   - inference:
       random_seed: 1337
+      final_step: 48
     contigmap:
       contigs: ["700-700"]
-    diffuser:
-      T: 15

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -217,8 +217,6 @@ def config_id(config):
         flattened["inference.input_pdb"] = pathlib.Path(
             flattened["inference.input_pdb"]
         ).stem
-    if "diffuser.T" in flattened:
-        flattened["diffuser.T"] = f"T{flattened['diffuser.T']}"
 
     fields = []
     for v in flattened.values():


### PR DESCRIPTION
I set this wrong. `diffuser.T` is the starting step and I think it's really a property of the model that gets overriden. To start at a later step you use `diffuser.partial_T` and to limit the number of steps `inference.final_step`.