### PR TITLE
Replace `torch.no_grad` with `torch.inference_mode`

### DIFF
--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -570,7 +570,7 @@ class Sampler:
         pair_prev = None
         state_prev = None
 
-        with torch.no_grad():
+        with torch.inference_mode():
             msa_prev, pair_prev, px0, state_prev, alpha, logits, plddt = self.model(msa_masked,
                                 msa_full,
                                 seq_in,
@@ -660,7 +660,7 @@ class SelfConditioning(Sampler):
         ### Forward Pass ###
         ####################
 
-        with torch.no_grad():
+        with torch.inference_mode():
             msa_prev, pair_prev, px0, state_prev, alpha, logits, plddt = self.model(msa_masked,
                                 msa_full,
                                 seq_in,


### PR DESCRIPTION
This is a drop-in replacement that turns more stuff off and should be safe as long as there aren't runtime errors
(https://discuss.pytorch.org/t/pytorch-torch-no-grad-vs-torch-inference-mode/134099). I didn't see huge speedups, but I also didn't see any runtime errors.