### PR TITLE
Thread device through model initialization

### DIFF
--- a/env/SE3Transformer/se3_transformer/model/layers/attention.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/attention.py
@@ -44,7 +44,8 @@ class AttentionSE3(nn.Module):
             self,
             num_heads: int,
             key_fiber: Fiber,
-            value_fiber: Fiber
+            value_fiber: Fiber,
+            device=None,
     ):
         """
         :param num_heads:     Number of attention heads
@@ -117,6 +118,7 @@ class AttentionBlockSE3(nn.Module):
             max_degree: bool = 4,
             fuse_level: ConvSE3FuseLevel = ConvSE3FuseLevel.FULL,
             low_memory: bool = False,
+            device=None,
             **kwargs
     ):
         """
@@ -141,10 +143,10 @@ class AttentionBlockSE3(nn.Module):
 
         self.to_key_value = ConvSE3(fiber_in, value_fiber + key_query_fiber, pool=False, fiber_edge=fiber_edge,
                                     use_layer_norm=use_layer_norm, max_degree=max_degree, fuse_level=fuse_level,
-                                    allow_fused_output=True, low_memory=low_memory)
-        self.to_query = LinearSE3(fiber_in, key_query_fiber)
-        self.attention = AttentionSE3(num_heads, key_query_fiber, value_fiber)
-        self.project = LinearSE3(value_fiber + fiber_in, fiber_out)
+                                    allow_fused_output=True, low_memory=low_memory, device=device)
+        self.to_query = LinearSE3(fiber_in, key_query_fiber, device=device)
+        self.attention = AttentionSE3(num_heads, key_query_fiber, value_fiber, device=device)
+        self.project = LinearSE3(value_fiber + fiber_in, fiber_out, device=device)
 
     def forward(
             self,

--- a/env/SE3Transformer/se3_transformer/model/layers/convolution.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/convolution.py
@@ -92,7 +92,8 @@ class RadialProfile(nn.Module):
             channels_out: int,
             edge_dim: int = 1,
             mid_dim: int = 32,
-            use_layer_norm: bool = False
+            use_layer_norm: bool = False,
+            device=None,
     ):
         """
         :param num_freq:         Number of frequencies
@@ -104,13 +105,13 @@ class RadialProfile(nn.Module):
         """
         super().__init__()
         modules = [
-            nn.Linear(edge_dim, mid_dim),
-            nn.LayerNorm(mid_dim) if use_layer_norm else None,
+            nn.Linear(edge_dim, mid_dim, device=device),
+            nn.LayerNorm(mid_dim, device=device) if use_layer_norm else None,
             nn.ReLU(),
-            nn.Linear(mid_dim, mid_dim),
-            nn.LayerNorm(mid_dim) if use_layer_norm else None,
+            nn.Linear(mid_dim, mid_dim, device=device),
+            nn.LayerNorm(mid_dim, device=device) if use_layer_norm else None,
             nn.ReLU(),
-            nn.Linear(mid_dim, num_freq * channels_in * channels_out, bias=False)
+            nn.Linear(mid_dim, num_freq * channels_in * channels_out, bias=False, device=device)
         ]
 
         self.net = torch.jit.script(nn.Sequential(*[m for m in modules if m is not None]))
@@ -131,7 +132,8 @@ class VersatileConvSE3(nn.Module):
                  channels_out: int,
                  edge_dim: int,
                  use_layer_norm: bool,
-                 fuse_level: ConvSE3FuseLevel):
+                 fuse_level: ConvSE3FuseLevel,
+                 device=None):
         super().__init__()
         self.freq_sum = freq_sum
         self.channels_out = channels_out
@@ -141,7 +143,8 @@ class VersatileConvSE3(nn.Module):
                                          channels_in=channels_in,
                                          channels_out=channels_out,
                                          edge_dim=edge_dim,
-                                         use_layer_norm=use_layer_norm)
+                                         use_layer_norm=use_layer_norm,
+                                         device=device)
 
     def forward(self, features: Tensor, invariant_edge_feats: Tensor, basis: Tensor):
         with nvtx_range(f'VersatileConvSE3'):
@@ -187,7 +190,8 @@ class ConvSE3(nn.Module):
             max_degree: int = 4,
             fuse_level: ConvSE3FuseLevel = ConvSE3FuseLevel.FULL,
             allow_fused_output: bool = False,
-            low_memory: bool = False
+            low_memory: bool = False,
+            device=None,
     ):
         """
         :param fiber_in:           Fiber describing the input features
@@ -216,6 +220,7 @@ class ConvSE3(nn.Module):
         unique_channels_out = (len(channels_out_set) == 1)
         degrees_up_to_max = list(range(max_degree + 1))
         common_args = dict(edge_dim=fiber_edge[0] + 1, use_layer_norm=use_layer_norm)
+        common_args["device"] = device
 
         if fuse_level.value >= ConvSE3FuseLevel.FULL.value and \
                 unique_channels_in and fiber_in.degrees == degrees_up_to_max and \
@@ -267,7 +272,7 @@ class ConvSE3(nn.Module):
             for degree_out, channels_out in fiber_out:
                 if fiber_in[degree_out]:
                     self.to_kernel_self[str(degree_out)] = nn.Parameter(
-                        torch.randn(channels_out, fiber_in[degree_out]) / np.sqrt(fiber_in[degree_out]))
+                        torch.randn(channels_out, fiber_in[degree_out], device=device) / np.sqrt(fiber_in[degree_out]))
 
     def _try_unpad(self, feature, basis):
         # Account for padded basis

--- a/env/SE3Transformer/se3_transformer/model/layers/linear.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/linear.py
@@ -44,11 +44,11 @@ class LinearSE3(nn.Module):
     type-k features (C_k channels) ────> Linear(bias=False) ────> type-k features (C'_k channels)
     """
 
-    def __init__(self, fiber_in: Fiber, fiber_out: Fiber):
+    def __init__(self, fiber_in: Fiber, fiber_out: Fiber, device=None):
         super().__init__()
         self.weights = nn.ParameterDict({
             str(degree_out): nn.Parameter(
-                torch.randn(channels_out, fiber_in[degree_out]) / np.sqrt(fiber_in[degree_out]))
+                torch.randn(channels_out, fiber_in[degree_out], device=device) / torch.sqrt(torch.tensor(fiber_in[degree_out], device=device)))
             for degree_out, channels_out in fiber_out
         })
 

--- a/env/SE3Transformer/se3_transformer/model/layers/norm.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/norm.py
@@ -52,18 +52,18 @@ class NormSE3(nn.Module):
 
     NORM_CLAMP = 2 ** -24  # Minimum positive subnormal for FP16
 
-    def __init__(self, fiber: Fiber, nonlinearity: nn.Module = nn.ReLU()):
+    def __init__(self, fiber: Fiber, nonlinearity: nn.Module = nn.ReLU(), device=None):
         super().__init__()
         self.fiber = fiber
         self.nonlinearity = nonlinearity
 
         if len(set(fiber.channels)) == 1:
             # Fuse all the layer normalizations into a group normalization
-            self.group_norm = nn.GroupNorm(num_groups=len(fiber.degrees), num_channels=sum(fiber.channels))
+            self.group_norm = nn.GroupNorm(num_groups=len(fiber.degrees), num_channels=sum(fiber.channels), device=device)
         else:
             # Use multiple layer normalizations
             self.layer_norms = nn.ModuleDict({
-                str(degree): nn.LayerNorm(channels)
+                str(degree): nn.LayerNorm(channels, device=device)
                 for degree, channels in fiber
             })
 

--- a/env/SE3Transformer/se3_transformer/model/transformer.py
+++ b/env/SE3Transformer/se3_transformer/model/transformer.py
@@ -74,6 +74,7 @@ class SE3Transformer(nn.Module):
                  use_layer_norm: bool = True,
                  tensor_cores: bool = False,
                  low_memory: bool = False,
+                 device=None,
                  **kwargs):
         """
         :param num_layers:          Number of attention layers
@@ -117,9 +118,10 @@ class SE3Transformer(nn.Module):
                                                    use_layer_norm=use_layer_norm,
                                                    max_degree=self.max_degree,
                                                    fuse_level=self.fuse_level,
-                                                   low_memory=low_memory))
+                                                   low_memory=low_memory,
+                                                   device=device))
             if norm:
-                graph_modules.append(NormSE3(fiber_hidden))
+                graph_modules.append(NormSE3(fiber_hidden, device=device))
             fiber_in = fiber_hidden
 
         graph_modules.append(ConvSE3(fiber_in=fiber_in,
@@ -129,12 +131,13 @@ class SE3Transformer(nn.Module):
                                      use_layer_norm=use_layer_norm,
                                      max_degree=self.max_degree,
                                      fuse_level=self.fuse_level,
-                                     low_memory=low_memory))
+                                     low_memory=low_memory,
+                                     device=device))
         self.graph_modules = Sequential(*graph_modules)
 
         if pooling is not None:
             assert return_type is not None, 'return_type must be specified when pooling'
-            self.pooling_module = GPooling(pool=pooling, feat_type=return_type)
+            self.pooling_module = GPooling(pool=pooling, feat_type=return_type, device=device)
 
     def forward(self, graph: DGLGraph, node_feats: Dict[str, Tensor],
                 edge_feats: Optional[Dict[str, Tensor]] = None,

--- a/rfdiffusion/Attention_module.py
+++ b/rfdiffusion/Attention_module.py
@@ -5,12 +5,12 @@ import math
 from rfdiffusion.util_module import init_lecun_normal
 
 class FeedForwardLayer(nn.Module):
-    def __init__(self, d_model, r_ff, p_drop=0.1):
+    def __init__(self, d_model, r_ff, p_drop=0.1, device=None):
         super(FeedForwardLayer, self).__init__()
-        self.norm = nn.LayerNorm(d_model)
-        self.linear1 = nn.Linear(d_model, d_model*r_ff)
+        self.norm = nn.LayerNorm(d_model, device=device)
+        self.linear1 = nn.Linear(d_model, d_model*r_ff, device=device)
         self.dropout = nn.Dropout(p_drop)
-        self.linear2 = nn.Linear(d_model*r_ff, d_model)
+        self.linear2 = nn.Linear(d_model*r_ff, d_model, device=device)
 
         self.reset_parameter()
 
@@ -30,16 +30,16 @@ class FeedForwardLayer(nn.Module):
 
 class Attention(nn.Module):
     # calculate multi-head attention
-    def __init__(self, d_query, d_key, n_head, d_hidden, d_out):
+    def __init__(self, d_query, d_key, n_head, d_hidden, d_out, device=None):
         super(Attention, self).__init__()
         self.h = n_head
         self.dim = d_hidden
         #
-        self.to_q = nn.Linear(d_query, n_head*d_hidden, bias=False)
-        self.to_k = nn.Linear(d_key, n_head*d_hidden, bias=False)
-        self.to_v = nn.Linear(d_key, n_head*d_hidden, bias=False)
+        self.to_q = nn.Linear(d_query, n_head*d_hidden, bias=False, device=device)
+        self.to_k = nn.Linear(d_key, n_head*d_hidden, bias=False, device=device)
+        self.to_v = nn.Linear(d_key, n_head*d_hidden, bias=False, device=device)
         #
-        self.to_out = nn.Linear(n_head*d_hidden, d_out)
+        self.to_out = nn.Linear(n_head*d_hidden, d_out, device=device)
         self.scaling = 1/math.sqrt(d_hidden)
         #
         # initialize all parameters properly
@@ -135,14 +135,14 @@ class AttentionWithBias(nn.Module):
 
 # MSA Attention (row/column) from AlphaFold architecture
 class SequenceWeight(nn.Module):
-    def __init__(self, d_msa, n_head, d_hidden, p_drop=0.1):
+    def __init__(self, d_msa, n_head, d_hidden, p_drop=0.1, device=None):
         super(SequenceWeight, self).__init__()
         self.h = n_head
         self.dim = d_hidden
         self.scale = 1.0 / math.sqrt(self.dim)
 
-        self.to_query = nn.Linear(d_msa, n_head*d_hidden)
-        self.to_key = nn.Linear(d_msa, n_head*d_hidden)
+        self.to_query = nn.Linear(d_msa, n_head*d_hidden, device=device)
+        self.to_key = nn.Linear(d_msa, n_head*d_hidden, device=device)
         self.dropout = nn.Dropout(p_drop)
 
         self.reset_parameter()
@@ -166,33 +166,33 @@ class SequenceWeight(nn.Module):
         return self.dropout(attn)
 
 class MSARowAttentionWithBias(nn.Module):
-    def __init__(self, d_msa=256, d_pair=128, n_head=8, d_hidden=32):
+    def __init__(self, d_msa=256, d_pair=128, n_head=8, d_hidden=32, device=None):
         super(MSARowAttentionWithBias, self).__init__()
-        self.norm_msa = nn.LayerNorm(d_msa)
-        self.norm_pair = nn.LayerNorm(d_pair)
+        self.norm_msa = nn.LayerNorm(d_msa, device=device)
+        self.norm_pair = nn.LayerNorm(d_pair, device=device)
         #
-        self.seq_weight = SequenceWeight(d_msa, n_head, d_hidden, p_drop=0.1)
-        self.to_q = nn.Linear(d_msa, n_head*d_hidden, bias=False)
-        self.to_k = nn.Linear(d_msa, n_head*d_hidden, bias=False)
-        self.to_v = nn.Linear(d_msa, n_head*d_hidden, bias=False)
-        self.to_b = nn.Linear(d_pair, n_head, bias=False)
-        self.to_g = nn.Linear(d_msa, n_head*d_hidden)
-        self.to_out = nn.Linear(n_head*d_hidden, d_msa)
+        self.seq_weight = SequenceWeight(d_msa, n_head, d_hidden, p_drop=0.1, device=device)
+        self.to_q = nn.Linear(d_msa, n_head*d_hidden, bias=False, device=device)
+        self.to_k = nn.Linear(d_msa, n_head*d_hidden, bias=False, device=device)
+        self.to_v = nn.Linear(d_msa, n_head*d_hidden, bias=False, device=device)
+        self.to_b = nn.Linear(d_pair, n_head, bias=False, device=device)
+        self.to_g = nn.Linear(d_msa, n_head*d_hidden, device=device)
+        self.to_out = nn.Linear(n_head*d_hidden, d_msa, device=device)
 
         self.scaling = 1/math.sqrt(d_hidden)
         self.h = n_head
         self.dim = d_hidden
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
         # query/key/value projection: Glorot uniform / Xavier uniform
         nn.init.xavier_uniform_(self.to_q.weight)
         nn.init.xavier_uniform_(self.to_k.weight)
         nn.init.xavier_uniform_(self.to_v.weight)
 
         # bias: normal distribution
-        self.to_b = init_lecun_normal(self.to_b)
+        self.to_b = init_lecun_normal(self.to_b, device=device)
 
         # gating: zero weights, one biases (mostly open gate at the begining)
         nn.init.zeros_(self.to_g.weight)
@@ -228,15 +228,15 @@ class MSARowAttentionWithBias(nn.Module):
         return out
 
 class MSAColAttention(nn.Module):
-    def __init__(self, d_msa=256, n_head=8, d_hidden=32):
+    def __init__(self, d_msa=256, n_head=8, d_hidden=32, device=None):
         super(MSAColAttention, self).__init__()
-        self.norm_msa = nn.LayerNorm(d_msa)
+        self.norm_msa = nn.LayerNorm(d_msa, device=device)
         #
-        self.to_q = nn.Linear(d_msa, n_head*d_hidden, bias=False)
-        self.to_k = nn.Linear(d_msa, n_head*d_hidden, bias=False)
-        self.to_v = nn.Linear(d_msa, n_head*d_hidden, bias=False)
-        self.to_g = nn.Linear(d_msa, n_head*d_hidden)
-        self.to_out = nn.Linear(n_head*d_hidden, d_msa)
+        self.to_q = nn.Linear(d_msa, n_head*d_hidden, bias=False, device=device)
+        self.to_k = nn.Linear(d_msa, n_head*d_hidden, bias=False, device=device)
+        self.to_v = nn.Linear(d_msa, n_head*d_hidden, bias=False, device=device)
+        self.to_g = nn.Linear(d_msa, n_head*d_hidden, device=device)
+        self.to_out = nn.Linear(n_head*d_hidden, d_msa, device=device)
 
         self.scaling = 1/math.sqrt(d_hidden)
         self.h = n_head
@@ -279,15 +279,15 @@ class MSAColAttention(nn.Module):
         return out
 
 class MSAColGlobalAttention(nn.Module):
-    def __init__(self, d_msa=64, n_head=8, d_hidden=8):
+    def __init__(self, d_msa=64, n_head=8, d_hidden=8, device=None):
         super(MSAColGlobalAttention, self).__init__()
-        self.norm_msa = nn.LayerNorm(d_msa)
+        self.norm_msa = nn.LayerNorm(d_msa, device=device)
         #
-        self.to_q = nn.Linear(d_msa, n_head*d_hidden, bias=False)
-        self.to_k = nn.Linear(d_msa, d_hidden, bias=False)
-        self.to_v = nn.Linear(d_msa, d_hidden, bias=False)
-        self.to_g = nn.Linear(d_msa, n_head*d_hidden)
-        self.to_out = nn.Linear(n_head*d_hidden, d_msa)
+        self.to_q = nn.Linear(d_msa, n_head*d_hidden, bias=False, device=device)
+        self.to_k = nn.Linear(d_msa, d_hidden, bias=False, device=device)
+        self.to_v = nn.Linear(d_msa, d_hidden, bias=False, device=device)
+        self.to_g = nn.Linear(d_msa, n_head*d_hidden, device=device)
+        self.to_out = nn.Linear(n_head*d_hidden, d_msa, device=device)
 
         self.scaling = 1/math.sqrt(d_hidden)
         self.h = n_head
@@ -332,35 +332,35 @@ class MSAColGlobalAttention(nn.Module):
 
 # Instead of triangle attention, use Tied axail attention with bias from coordinates..?
 class BiasedAxialAttention(nn.Module):
-    def __init__(self, d_pair, d_bias, n_head, d_hidden, p_drop=0.1, is_row=True):
+    def __init__(self, d_pair, d_bias, n_head, d_hidden, p_drop=0.1, is_row=True, device=None):
         super(BiasedAxialAttention, self).__init__()
         #
         self.is_row = is_row
-        self.norm_pair = nn.LayerNorm(d_pair)
-        self.norm_bias = nn.LayerNorm(d_bias)
+        self.norm_pair = nn.LayerNorm(d_pair, device=device)
+        self.norm_bias = nn.LayerNorm(d_bias, device=device)
 
-        self.to_q = nn.Linear(d_pair, n_head*d_hidden, bias=False)
-        self.to_k = nn.Linear(d_pair, n_head*d_hidden, bias=False)
-        self.to_v = nn.Linear(d_pair, n_head*d_hidden, bias=False)
-        self.to_b = nn.Linear(d_bias, n_head, bias=False)
-        self.to_g = nn.Linear(d_pair, n_head*d_hidden)
-        self.to_out = nn.Linear(n_head*d_hidden, d_pair)
+        self.to_q = nn.Linear(d_pair, n_head*d_hidden, bias=False, device=device)
+        self.to_k = nn.Linear(d_pair, n_head*d_hidden, bias=False, device=device)
+        self.to_v = nn.Linear(d_pair, n_head*d_hidden, bias=False, device=device)
+        self.to_b = nn.Linear(d_bias, n_head, bias=False, device=device)
+        self.to_g = nn.Linear(d_pair, n_head*d_hidden, device=device)
+        self.to_out = nn.Linear(n_head*d_hidden, d_pair, device=device)
 
         self.scaling = 1/math.sqrt(d_hidden)
         self.h = n_head
         self.dim = d_hidden
 
         # initialize all parameters properly
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
         # query/key/value projection: Glorot uniform / Xavier uniform
         nn.init.xavier_uniform_(self.to_q.weight)
         nn.init.xavier_uniform_(self.to_k.weight)
         nn.init.xavier_uniform_(self.to_v.weight)
 
         # bias: normal distribution
-        self.to_b = init_lecun_normal(self.to_b)
+        self.to_b = init_lecun_normal(self.to_b, device=device)
 
         # gating: zero weights, one biases (mostly open gate at the begining)
         nn.init.zeros_(self.to_g.weight)

--- a/rfdiffusion/AuxiliaryPredictor.py
+++ b/rfdiffusion/AuxiliaryPredictor.py
@@ -2,11 +2,11 @@ import torch
 import torch.nn as nn
 
 class DistanceNetwork(nn.Module):
-    def __init__(self, n_feat, p_drop=0.1):
+    def __init__(self, n_feat, p_drop=0.1, device=None):
         super(DistanceNetwork, self).__init__()
         #
-        self.proj_symm = nn.Linear(n_feat, 37*2)
-        self.proj_asymm = nn.Linear(n_feat, 37+19)
+        self.proj_symm = nn.Linear(n_feat, 37*2, device=device)
+        self.proj_asymm = nn.Linear(n_feat, 37+19, device=device)
 
         self.reset_parameter()
 
@@ -34,9 +34,9 @@ class DistanceNetwork(nn.Module):
         return logits_dist, logits_omega, logits_theta, logits_phi
 
 class MaskedTokenNetwork(nn.Module):
-    def __init__(self, n_feat):
+    def __init__(self, n_feat, device=None):
         super(MaskedTokenNetwork, self).__init__()
-        self.proj = nn.Linear(n_feat, 21)
+        self.proj = nn.Linear(n_feat, 21, device=device)
 
         self.reset_parameter()
 
@@ -51,9 +51,9 @@ class MaskedTokenNetwork(nn.Module):
         return logits
 
 class LDDTNetwork(nn.Module):
-    def __init__(self, n_feat, n_bin_lddt=50):
+    def __init__(self, n_feat, n_bin_lddt=50, device=None):
         super(LDDTNetwork, self).__init__()
-        self.proj = nn.Linear(n_feat, n_bin_lddt)
+        self.proj = nn.Linear(n_feat, n_bin_lddt, device=device)
 
         self.reset_parameter()
 
@@ -67,11 +67,11 @@ class LDDTNetwork(nn.Module):
         return logits.permute(0,2,1)
 
 class ExpResolvedNetwork(nn.Module):
-    def __init__(self, d_msa, d_state, p_drop=0.1):
+    def __init__(self, d_msa, d_state, p_drop=0.1, device=None):
         super(ExpResolvedNetwork, self).__init__()
-        self.norm_msa = nn.LayerNorm(d_msa)
-        self.norm_state = nn.LayerNorm(d_state)
-        self.proj = nn.Linear(d_msa+d_state, 1)
+        self.norm_msa = nn.LayerNorm(d_msa, device=device)
+        self.norm_state = nn.LayerNorm(d_state, device=device)
+        self.proj = nn.Linear(d_msa+d_state, 1, device=device)
 
         self.reset_parameter()
 

--- a/rfdiffusion/Embeddings.py
+++ b/rfdiffusion/Embeddings.py
@@ -12,12 +12,12 @@ import math
 
 class PositionalEncoding2D(nn.Module):
     # Add relative positional encoding to pair features
-    def __init__(self, d_model, minpos=-32, maxpos=32, p_drop=0.1):
+    def __init__(self, d_model, minpos=-32, maxpos=32, p_drop=0.1, device=None):
         super(PositionalEncoding2D, self).__init__()
         self.minpos = minpos
         self.maxpos = maxpos
         self.nbin = abs(minpos)+maxpos+1
-        self.emb = nn.Embedding(self.nbin, d_model)
+        self.emb = nn.Embedding(self.nbin, d_model, device=device)
         self.drop = nn.Dropout(p_drop)
 
     def forward(self, x, idx):
@@ -32,26 +32,26 @@ class PositionalEncoding2D(nn.Module):
 class MSA_emb(nn.Module):
     # Get initial seed MSA embedding
     def __init__(self, d_msa=256, d_pair=128, d_state=32, d_init=22+22+2+2,
-                 minpos=-32, maxpos=32, p_drop=0.1, input_seq_onehot=False):
+                 minpos=-32, maxpos=32, p_drop=0.1, input_seq_onehot=False, device=None):
         super(MSA_emb, self).__init__()
-        self.emb = nn.Linear(d_init, d_msa) # embedding for general MSA
-        self.emb_q = nn.Embedding(22, d_msa) # embedding for query sequence -- used for MSA embedding
-        self.emb_left = nn.Embedding(22, d_pair) # embedding for query sequence -- used for pair embedding
-        self.emb_right = nn.Embedding(22, d_pair) # embedding for query sequence -- used for pair embedding
-        self.emb_state = nn.Embedding(22, d_state)
+        self.emb = nn.Linear(d_init, d_msa, device=device) # embedding for general MSA
+        self.emb_q = nn.Embedding(22, d_msa, device=device) # embedding for query sequence -- used for MSA embedding
+        self.emb_left = nn.Embedding(22, d_pair, device=device) # embedding for query sequence -- used for pair embedding
+        self.emb_right = nn.Embedding(22, d_pair, device=device) # embedding for query sequence -- used for pair embedding
+        self.emb_state = nn.Embedding(22, d_state, device=device)
         self.drop = nn.Dropout(p_drop)
-        self.pos = PositionalEncoding2D(d_pair, minpos=minpos, maxpos=maxpos, p_drop=p_drop)
+        self.pos = PositionalEncoding2D(d_pair, minpos=minpos, maxpos=maxpos, p_drop=p_drop, device=device)
 
         self.input_seq_onehot=input_seq_onehot
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
-        self.emb = init_lecun_normal(self.emb)
-        self.emb_q = init_lecun_normal(self.emb_q)
-        self.emb_left = init_lecun_normal(self.emb_left)
-        self.emb_right = init_lecun_normal(self.emb_right)
-        self.emb_state = init_lecun_normal(self.emb_state)
+    def reset_parameter(self, device=None):
+        self.emb = init_lecun_normal(self.emb, device=device)
+        self.emb_q = init_lecun_normal(self.emb_q, device=device)
+        self.emb_left = init_lecun_normal(self.emb_left, device=device)
+        self.emb_right = init_lecun_normal(self.emb_right, device=device)
+        self.emb_state = init_lecun_normal(self.emb_state, device=device)
 
         nn.init.zeros_(self.emb.bias)
 
@@ -90,18 +90,18 @@ class MSA_emb(nn.Module):
 
 class Extra_emb(nn.Module):
     # Get initial seed MSA embedding
-    def __init__(self, d_msa=256, d_init=22+1+2, p_drop=0.1, input_seq_onehot=False):
+    def __init__(self, d_msa=256, d_init=22+1+2, p_drop=0.1, input_seq_onehot=False, device=None):
         super(Extra_emb, self).__init__()
-        self.emb = nn.Linear(d_init, d_msa) # embedding for general MSA
-        self.emb_q = nn.Embedding(22, d_msa) # embedding for query sequence
+        self.emb = nn.Linear(d_init, d_msa, device=device) # embedding for general MSA
+        self.emb_q = nn.Embedding(22, d_msa, device=device) # embedding for query sequence
         self.drop = nn.Dropout(p_drop)
 
         self.input_seq_onehot=input_seq_onehot
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
-        self.emb = init_lecun_normal(self.emb)
+    def reset_parameter(self, device=None):
+        self.emb = init_lecun_normal(self.emb, device=device)
         nn.init.zeros_(self.emb.bias)
 
     def forward(self, msa, seq, idx):
@@ -122,12 +122,13 @@ class Extra_emb(nn.Module):
 class TemplatePairStack(nn.Module):
     # process template pairwise features
     # use structure-biased attention
-    def __init__(self, n_block=2, d_templ=64, n_head=4, d_hidden=16, p_drop=0.25):
+    def __init__(self, n_block=2, d_templ=64, n_head=4, d_hidden=16, p_drop=0.25, device=None):
         super(TemplatePairStack, self).__init__()
         self.n_block = n_block
-        proc_s = [PairStr2Pair(d_pair=d_templ, n_head=n_head, d_hidden=d_hidden, p_drop=p_drop) for i in range(n_block)]
+        proc_s = [PairStr2Pair(d_pair=d_templ, n_head=n_head, d_hidden=d_hidden, p_drop=p_drop, device=device) for i in range(n_block)]
         self.block = nn.ModuleList(proc_s)
-        self.norm = nn.LayerNorm(d_templ)
+        self.norm = nn.LayerNorm(d_templ, device=device)
+
     def forward(self, templ, rbf_feat, use_checkpoint=False):
         B, T, L = templ.shape[:3]
         templ = templ.reshape(B*T, L, L, -1)
@@ -185,32 +186,32 @@ class Templ_emb(nn.Module):
     #Added extra t1d dimension for contacting or not
     def __init__(self, d_t1d=21+1+1, d_t2d=43+1, d_tor=30, d_pair=128, d_state=32,
                  n_block=2, d_templ=64,
-                 n_head=4, d_hidden=16, p_drop=0.25):
+                 n_head=4, d_hidden=16, p_drop=0.25, device=None):
         super(Templ_emb, self).__init__()
         # process 2D features
-        self.emb = nn.Linear(d_t1d*2+d_t2d, d_templ)
+        self.emb = nn.Linear(d_t1d*2+d_t2d, d_templ, device=device)
         self.templ_stack = TemplatePairStack(n_block=n_block, d_templ=d_templ, n_head=n_head,
-                                             d_hidden=d_hidden, p_drop=p_drop)
+                                             d_hidden=d_hidden, p_drop=p_drop, device=device)
 
-        self.attn = Attention(d_pair, d_templ, n_head, d_hidden, d_pair)
+        self.attn = Attention(d_pair, d_templ, n_head, d_hidden, d_pair, device=device)
 
         # process torsion angles
-        self.emb_t1d = nn.Linear(d_t1d+d_tor, d_templ)
-        self.proj_t1d = nn.Linear(d_templ, d_templ)
+        self.emb_t1d = nn.Linear(d_t1d+d_tor, d_templ, device=device)
+        self.proj_t1d = nn.Linear(d_templ, d_templ, device=device)
         #self.tor_stack = TemplateTorsionStack(n_block=n_block, d_templ=d_templ, n_head=n_head,
         #                                      d_hidden=d_hidden, p_drop=p_drop)
-        self.attn_tor = Attention(d_state, d_templ, n_head, d_hidden, d_state)
+        self.attn_tor = Attention(d_state, d_templ, n_head, d_hidden, d_state, device=device)
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
-        self.emb = init_lecun_normal(self.emb)
+    def reset_parameter(self, device=None):
+        self.emb = init_lecun_normal(self.emb, device=device)
         nn.init.zeros_(self.emb.bias)
 
         nn.init.kaiming_normal_(self.emb_t1d.weight, nonlinearity='relu')
         nn.init.zeros_(self.emb_t1d.bias)
 
-        self.proj_t1d = init_lecun_normal(self.proj_t1d)
+        self.proj_t1d = init_lecun_normal(self.proj_t1d, device=device)
         nn.init.zeros_(self.proj_t1d.bias)
 
     def forward(self, t1d, t2d, alpha_t, xyz_t, pair, state, use_checkpoint=False):
@@ -262,17 +263,17 @@ class Templ_emb(nn.Module):
         return pair, state
 
 class Recycling(nn.Module):
-    def __init__(self, d_msa=256, d_pair=128, d_state=32):
+    def __init__(self, d_msa=256, d_pair=128, d_state=32, device=None):
         super(Recycling, self).__init__()
-        self.proj_dist = nn.Linear(36+d_state*2, d_pair)
-        self.norm_state = nn.LayerNorm(d_state)
-        self.norm_pair = nn.LayerNorm(d_pair)
-        self.norm_msa = nn.LayerNorm(d_msa)
+        self.proj_dist = nn.Linear(36+d_state*2, d_pair, device=device)
+        self.norm_state = nn.LayerNorm(d_state, device=device)
+        self.norm_pair = nn.LayerNorm(d_pair, device=device)
+        self.norm_msa = nn.LayerNorm(d_msa, device=device)
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
-        self.proj_dist = init_lecun_normal(self.proj_dist)
+    def reset_parameter(self, device=None):
+        self.proj_dist = init_lecun_normal(self.proj_dist, device=device)
         nn.init.zeros_(self.proj_dist.bias)
 
     def forward(self, seq, msa, pair, xyz, state):

--- a/rfdiffusion/RoseTTAFoldModel.py
+++ b/rfdiffusion/RoseTTAFoldModel.py
@@ -27,6 +27,7 @@ class RoseTTAFoldModule(nn.Module):
                  SE3_param_full={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32},
                  SE3_param_topk={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32},
                  input_seq_onehot=False,     # For continuous vs. discrete sequence
+                 device=None,
                  ):
 
         super(RoseTTAFoldModule, self).__init__()
@@ -36,16 +37,16 @@ class RoseTTAFoldModule(nn.Module):
         # Input Embeddings
         d_state = SE3_param_topk['l0_out_features']
         self.latent_emb = MSA_emb(d_msa=d_msa, d_pair=d_pair, d_state=d_state,
-                p_drop=p_drop, input_seq_onehot=input_seq_onehot) # Allowed to take onehotseq
+                p_drop=p_drop, input_seq_onehot=input_seq_onehot, device=device) # Allowed to take onehotseq
         self.full_emb = Extra_emb(d_msa=d_msa_full, d_init=25,
-                p_drop=p_drop, input_seq_onehot=input_seq_onehot) # Allowed to take onehotseq
+                p_drop=p_drop, input_seq_onehot=input_seq_onehot, device=device) # Allowed to take onehotseq
         self.templ_emb = Templ_emb(d_pair=d_pair, d_templ=d_templ, d_state=d_state,
                                    n_head=n_head_templ,
-                                   d_hidden=d_hidden_templ, p_drop=0.25, d_t1d=d_t1d, d_t2d=d_t2d)
+                                   d_hidden=d_hidden_templ, p_drop=0.25, d_t1d=d_t1d, d_t2d=d_t2d, device=device)
 
 
         # Update inputs with outputs from previous round
-        self.recycle = Recycling(d_msa=d_msa, d_pair=d_pair, d_state=d_state)
+        self.recycle = Recycling(d_msa=d_msa, d_pair=d_pair, d_state=d_state, device=device)
         #
         self.simulator = IterativeSimulator(n_extra_block=n_extra_block,
                                             n_main_block=n_main_block,
@@ -56,13 +57,13 @@ class RoseTTAFoldModule(nn.Module):
                                             n_head_pair=n_head_pair,
                                             SE3_param_full=SE3_param_full,
                                             SE3_param_topk=SE3_param_topk,
-                                            p_drop=p_drop)
+                                            p_drop=p_drop, device=device)
         ##
-        self.c6d_pred = DistanceNetwork(d_pair, p_drop=p_drop)
-        self.aa_pred = MaskedTokenNetwork(d_msa)
-        self.lddt_pred = LDDTNetwork(d_state)
+        self.c6d_pred = DistanceNetwork(d_pair, p_drop=p_drop, device=device)
+        self.aa_pred = MaskedTokenNetwork(d_msa, device=device)
+        self.lddt_pred = LDDTNetwork(d_state, device=device)
 
-        self.exp_pred = ExpResolvedNetwork(d_msa, d_state)
+        self.exp_pred = ExpResolvedNetwork(d_msa, d_state, device=device)
 
     def forward(self, msa_latent, msa_full, seq, xyz, idx, t,
                 t1d=None, t2d=None, xyz_t=None, alpha_t=None,

--- a/rfdiffusion/SE3_network.py
+++ b/rfdiffusion/SE3_network.py
@@ -14,7 +14,7 @@ class SE3TransformerWrapper(nn.Module):
     def __init__(self, num_layers=2, num_channels=32, num_degrees=3, n_heads=4, div=4,
                  l0_in_features=32, l0_out_features=32,
                  l1_in_features=3, l1_out_features=2,
-                 num_edge_features=32):
+                 num_edge_features=32, device=None):
         super().__init__()
         # Build the network
         self.l1_in = l1_in_features
@@ -46,12 +46,13 @@ class SE3TransformerWrapper(nn.Module):
                                   num_heads=n_heads,
                                   channels_div=div,
                                   fiber_edge=fiber_edge,
-                                  use_layer_norm=True)
+                                  use_layer_norm=True,
+                                  device=device)
                                   #use_layer_norm=False)
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
 
         # make sure linear layer before ReLu are initialized with kaiming_normal_
         for n, p in self.se3.named_parameters():
@@ -61,7 +62,7 @@ class SE3TransformerWrapper(nn.Module):
                 continue
             else:
                 if "radial_func" not in n:
-                    p = init_lecun_normal_param(p)
+                    p = init_lecun_normal_param(p, device=device)
                 else:
                     if "net.6" in n:
                         nn.init.zeros_(p)

--- a/rfdiffusion/Track_module.py
+++ b/rfdiffusion/Track_module.py
@@ -12,28 +12,28 @@ from rfdiffusion.SE3_network import SE3TransformerWrapper
 # Update MSA with biased self-attention. bias from Pair & Str
 class MSAPairStr2MSA(nn.Module):
     def __init__(self, d_msa=256, d_pair=128, n_head=8, d_state=16,
-                 d_hidden=32, p_drop=0.15, use_global_attn=False):
+                 d_hidden=32, p_drop=0.15, use_global_attn=False, device=None):
         super(MSAPairStr2MSA, self).__init__()
-        self.norm_pair = nn.LayerNorm(d_pair)
-        self.proj_pair = nn.Linear(d_pair+36, d_pair)
-        self.norm_state = nn.LayerNorm(d_state)
-        self.proj_state = nn.Linear(d_state, d_msa)
-        self.drop_row = Dropout(broadcast_dim=1, p_drop=p_drop)
+        self.norm_pair = nn.LayerNorm(d_pair, device=device)
+        self.proj_pair = nn.Linear(d_pair+36, d_pair, device=device)
+        self.norm_state = nn.LayerNorm(d_state, device=device)
+        self.proj_state = nn.Linear(d_state, d_msa, device=device)
+        self.drop_row = Dropout(broadcast_dim=1, p_drop=p_drop, device=device)
         self.row_attn = MSARowAttentionWithBias(d_msa=d_msa, d_pair=d_pair,
-                                                n_head=n_head, d_hidden=d_hidden)
+                                                n_head=n_head, d_hidden=d_hidden, device=device)
         if use_global_attn:
-            self.col_attn = MSAColGlobalAttention(d_msa=d_msa, n_head=n_head, d_hidden=d_hidden)
+            self.col_attn = MSAColGlobalAttention(d_msa=d_msa, n_head=n_head, d_hidden=d_hidden, device=device)
         else:
-            self.col_attn = MSAColAttention(d_msa=d_msa, n_head=n_head, d_hidden=d_hidden)
-        self.ff = FeedForwardLayer(d_msa, 4, p_drop=p_drop)
+            self.col_attn = MSAColAttention(d_msa=d_msa, n_head=n_head, d_hidden=d_hidden, device=device)
+        self.ff = FeedForwardLayer(d_msa, 4, p_drop=p_drop, device=device)
 
         # Do proper initialization
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
         # initialize weights to normal distrib
-        self.proj_pair = init_lecun_normal(self.proj_pair)
-        self.proj_state = init_lecun_normal(self.proj_state)
+        self.proj_pair = init_lecun_normal(self.proj_pair, device=device)
+        self.proj_state = init_lecun_normal(self.proj_state, device=device)
 
         # initialize bias to zeros
         nn.init.zeros_(self.proj_pair.bias)
@@ -76,27 +76,27 @@ class MSAPairStr2MSA(nn.Module):
         return msa
 
 class PairStr2Pair(nn.Module):
-    def __init__(self, d_pair=128, n_head=4, d_hidden=32, d_rbf=36, p_drop=0.15):
+    def __init__(self, d_pair=128, n_head=4, d_hidden=32, d_rbf=36, p_drop=0.15, device=None):
         super(PairStr2Pair, self).__init__()
 
-        self.emb_rbf = nn.Linear(d_rbf, d_hidden)
-        self.proj_rbf = nn.Linear(d_hidden, d_pair)
+        self.emb_rbf = nn.Linear(d_rbf, d_hidden, device=device)
+        self.proj_rbf = nn.Linear(d_hidden, d_pair, device=device)
 
-        self.drop_row = Dropout(broadcast_dim=1, p_drop=p_drop)
-        self.drop_col = Dropout(broadcast_dim=2, p_drop=p_drop)
+        self.drop_row = Dropout(broadcast_dim=1, p_drop=p_drop, device=device)
+        self.drop_col = Dropout(broadcast_dim=2, p_drop=p_drop, device=device)
 
-        self.row_attn = BiasedAxialAttention(d_pair, d_pair, n_head, d_hidden, p_drop=p_drop, is_row=True)
-        self.col_attn = BiasedAxialAttention(d_pair, d_pair, n_head, d_hidden, p_drop=p_drop, is_row=False)
+        self.row_attn = BiasedAxialAttention(d_pair, d_pair, n_head, d_hidden, p_drop=p_drop, is_row=True, device=device)
+        self.col_attn = BiasedAxialAttention(d_pair, d_pair, n_head, d_hidden, p_drop=p_drop, is_row=False, device=device)
 
-        self.ff = FeedForwardLayer(d_pair, 2)
+        self.ff = FeedForwardLayer(d_pair, 2, device=device)
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
         nn.init.kaiming_normal_(self.emb_rbf.weight, nonlinearity='relu')
         nn.init.zeros_(self.emb_rbf.bias)
 
-        self.proj_rbf = init_lecun_normal(self.proj_rbf)
+        self.proj_rbf = init_lecun_normal(self.proj_rbf, device=device)
         nn.init.zeros_(self.proj_rbf.bias)
 
     def forward(self, pair, rbf_feat):
@@ -110,19 +110,19 @@ class PairStr2Pair(nn.Module):
         return pair
 
 class MSA2Pair(nn.Module):
-    def __init__(self, d_msa=256, d_pair=128, d_hidden=32, p_drop=0.15):
+    def __init__(self, d_msa=256, d_pair=128, d_hidden=32, p_drop=0.15, device=None):
         super(MSA2Pair, self).__init__()
-        self.norm = nn.LayerNorm(d_msa)
-        self.proj_left = nn.Linear(d_msa, d_hidden)
-        self.proj_right = nn.Linear(d_msa, d_hidden)
-        self.proj_out = nn.Linear(d_hidden*d_hidden, d_pair)
+        self.norm = nn.LayerNorm(d_msa, device=device)
+        self.proj_left = nn.Linear(d_msa, d_hidden, device=device)
+        self.proj_right = nn.Linear(d_msa, d_hidden, device=device)
+        self.proj_out = nn.Linear(d_hidden*d_hidden, d_pair, device=device)
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
         # normal initialization
-        self.proj_left = init_lecun_normal(self.proj_left)
-        self.proj_right = init_lecun_normal(self.proj_right)
+        self.proj_left = init_lecun_normal(self.proj_left, device=device)
+        self.proj_right = init_lecun_normal(self.proj_right, device=device)
         nn.init.zeros_(self.proj_left.bias)
         nn.init.zeros_(self.proj_right.bias)
 
@@ -144,29 +144,29 @@ class MSA2Pair(nn.Module):
         return pair
 
 class SCPred(nn.Module):
-    def __init__(self, d_msa=256, d_state=32, d_hidden=128, p_drop=0.15):
+    def __init__(self, d_msa=256, d_state=32, d_hidden=128, p_drop=0.15, device=None):
         super(SCPred, self).__init__()
-        self.norm_s0 = nn.LayerNorm(d_msa)
-        self.norm_si = nn.LayerNorm(d_state)
-        self.linear_s0 = nn.Linear(d_msa, d_hidden)
-        self.linear_si = nn.Linear(d_state, d_hidden)
+        self.norm_s0 = nn.LayerNorm(d_msa, device=device)
+        self.norm_si = nn.LayerNorm(d_state, device=device)
+        self.linear_s0 = nn.Linear(d_msa, d_hidden, device=device)
+        self.linear_si = nn.Linear(d_state, d_hidden, device=device)
 
         # ResNet layers
-        self.linear_1 = nn.Linear(d_hidden, d_hidden)
-        self.linear_2 = nn.Linear(d_hidden, d_hidden)
-        self.linear_3 = nn.Linear(d_hidden, d_hidden)
-        self.linear_4 = nn.Linear(d_hidden, d_hidden)
+        self.linear_1 = nn.Linear(d_hidden, d_hidden, device=device)
+        self.linear_2 = nn.Linear(d_hidden, d_hidden, device=device)
+        self.linear_3 = nn.Linear(d_hidden, d_hidden, device=device)
+        self.linear_4 = nn.Linear(d_hidden, d_hidden, device=device)
 
         # Final outputs
-        self.linear_out = nn.Linear(d_hidden, 20)
+        self.linear_out = nn.Linear(d_hidden, 20, device=device)
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
         # normal initialization
-        self.linear_s0 = init_lecun_normal(self.linear_s0)
-        self.linear_si = init_lecun_normal(self.linear_si)
-        self.linear_out = init_lecun_normal(self.linear_out)
+        self.linear_s0 = init_lecun_normal(self.linear_s0, device=device)
+        self.linear_si = init_lecun_normal(self.linear_si, device=device)
+        self.linear_out = init_lecun_normal(self.linear_out, device=device)
         nn.init.zeros_(self.linear_s0.bias)
         nn.init.zeros_(self.linear_si.bias)
         nn.init.zeros_(self.linear_out.bias)
@@ -206,33 +206,33 @@ class SCPred(nn.Module):
 
 class Str2Str(nn.Module):
     def __init__(self, d_msa=256, d_pair=128, d_state=16,
-            SE3_param={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32}, p_drop=0.1):
+            SE3_param={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32}, p_drop=0.1, device=None):
         super(Str2Str, self).__init__()
 
         # initial node & pair feature process
-        self.norm_msa = nn.LayerNorm(d_msa)
-        self.norm_pair = nn.LayerNorm(d_pair)
-        self.norm_state = nn.LayerNorm(d_state)
+        self.norm_msa = nn.LayerNorm(d_msa, device=device)
+        self.norm_pair = nn.LayerNorm(d_pair, device=device)
+        self.norm_state = nn.LayerNorm(d_state, device=device)
 
-        self.embed_x = nn.Linear(d_msa+d_state, SE3_param['l0_in_features'])
-        self.embed_e1 = nn.Linear(d_pair, SE3_param['num_edge_features'])
-        self.embed_e2 = nn.Linear(SE3_param['num_edge_features']+36+1, SE3_param['num_edge_features'])
+        self.embed_x = nn.Linear(d_msa+d_state, SE3_param['l0_in_features'], device=device)
+        self.embed_e1 = nn.Linear(d_pair, SE3_param['num_edge_features'], device=device)
+        self.embed_e2 = nn.Linear(SE3_param['num_edge_features']+36+1, SE3_param['num_edge_features'], device=device)
 
-        self.norm_node = nn.LayerNorm(SE3_param['l0_in_features'])
-        self.norm_edge1 = nn.LayerNorm(SE3_param['num_edge_features'])
-        self.norm_edge2 = nn.LayerNorm(SE3_param['num_edge_features'])
+        self.norm_node = nn.LayerNorm(SE3_param['l0_in_features'], device=device)
+        self.norm_edge1 = nn.LayerNorm(SE3_param['num_edge_features'], device=device)
+        self.norm_edge2 = nn.LayerNorm(SE3_param['num_edge_features'], device=device)
 
-        self.se3 = SE3TransformerWrapper(**SE3_param)
+        self.se3 = SE3TransformerWrapper(**SE3_param, device=device)
         self.sc_predictor = SCPred(d_msa=d_msa, d_state=SE3_param['l0_out_features'],
-                                   p_drop=p_drop)
+                                   p_drop=p_drop, device=device)
 
-        self.reset_parameter()
+        self.reset_parameter(device)
 
-    def reset_parameter(self):
+    def reset_parameter(self, device=None):
         # initialize weights to normal distribution
-        self.embed_x = init_lecun_normal(self.embed_x)
-        self.embed_e1 = init_lecun_normal(self.embed_e1)
-        self.embed_e2 = init_lecun_normal(self.embed_e2)
+        self.embed_x = init_lecun_normal(self.embed_x, device=device)
+        self.embed_e1 = init_lecun_normal(self.embed_e1, device=device)
+        self.embed_e2 = init_lecun_normal(self.embed_e2, device=device)
 
         # initialize bias to zeros
         nn.init.zeros_(self.embed_x.bias)
@@ -304,7 +304,8 @@ class IterBlock(nn.Module):
                  n_head_msa=8, n_head_pair=4,
                  use_global_attn=False,
                  d_hidden=32, d_hidden_msa=None, p_drop=0.15,
-                 SE3_param={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32}):
+                 SE3_param={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32},
+                 device=None):
         super(IterBlock, self).__init__()
         if d_hidden_msa == None:
             d_hidden_msa = d_hidden
@@ -313,16 +314,20 @@ class IterBlock(nn.Module):
                                       n_head=n_head_msa,
                                       d_state=SE3_param['l0_out_features'],
                                       use_global_attn=use_global_attn,
-                                      d_hidden=d_hidden_msa, p_drop=p_drop)
+                                      d_hidden=d_hidden_msa, p_drop=p_drop,
+                                      device=device)
         self.msa2pair = MSA2Pair(d_msa=d_msa, d_pair=d_pair,
-                                 d_hidden=d_hidden//2, p_drop=p_drop)
+                                 d_hidden=d_hidden//2, p_drop=p_drop,
+                                 device=device)
                                  #d_hidden=d_hidden, p_drop=p_drop)
         self.pair2pair = PairStr2Pair(d_pair=d_pair, n_head=n_head_pair,
-                                      d_hidden=d_hidden, p_drop=p_drop)
+                                      d_hidden=d_hidden, p_drop=p_drop,
+                                      device=device)
         self.str2str = Str2Str(d_msa=d_msa, d_pair=d_pair,
                                d_state=SE3_param['l0_out_features'],
                                SE3_param=SE3_param,
-                               p_drop=p_drop)
+                               p_drop=p_drop,
+                               device=device)
 
     def forward(self, msa, pair, R_in, T_in, xyz, state, idx, motif_mask, use_checkpoint=False):
         rbf_feat = rbf(torch.cdist(xyz[:,:,1,:], xyz[:,:,1,:]))
@@ -345,13 +350,13 @@ class IterativeSimulator(nn.Module):
                  n_head_msa=8, n_head_pair=4,
                  SE3_param_full={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32},
                  SE3_param_topk={'l0_in_features':32, 'l0_out_features':16, 'num_edge_features':32},
-                 p_drop=0.15):
+                 p_drop=0.15, device=None):
         super(IterativeSimulator, self).__init__()
         self.n_extra_block = n_extra_block
         self.n_main_block = n_main_block
         self.n_ref_block = n_ref_block
 
-        self.proj_state = nn.Linear(SE3_param_topk['l0_out_features'], SE3_param_full['l0_out_features'])
+        self.proj_state = nn.Linear(SE3_param_topk['l0_out_features'], SE3_param_full['l0_out_features'], device=device)
         # Update with extra sequences
         if n_extra_block > 0:
             self.extra_block = nn.ModuleList([IterBlock(d_msa=d_msa_full, d_pair=d_pair,
@@ -361,7 +366,7 @@ class IterativeSimulator(nn.Module):
                                                         d_hidden=d_hidden,
                                                         p_drop=p_drop,
                                                         use_global_attn=True,
-                                                        SE3_param=SE3_param_full)
+                                                        SE3_param=SE3_param_full, device=device)
                                                         for i in range(n_extra_block)])
 
         # Update with seed sequences
@@ -372,22 +377,23 @@ class IterativeSimulator(nn.Module):
                                                        d_hidden=d_hidden,
                                                        p_drop=p_drop,
                                                        use_global_attn=False,
-                                                       SE3_param=SE3_param_full)
+                                                       SE3_param=SE3_param_full, device=device)
                                                        for i in range(n_main_block)])
 
-        self.proj_state2 = nn.Linear(SE3_param_full['l0_out_features'], SE3_param_topk['l0_out_features'])
+        self.proj_state2 = nn.Linear(SE3_param_full['l0_out_features'], SE3_param_topk['l0_out_features'], device=device)
         # Final SE(3) refinement
         if n_ref_block > 0:
             self.str_refiner = Str2Str(d_msa=d_msa, d_pair=d_pair,
                                        d_state=SE3_param_topk['l0_out_features'],
                                        SE3_param=SE3_param_topk,
-                                       p_drop=p_drop)
+                                       p_drop=p_drop, device=device)
 
-        self.reset_parameter()
-    def reset_parameter(self):
-        self.proj_state = init_lecun_normal(self.proj_state)
+        self.reset_parameter(device)
+
+    def reset_parameter(self, device=None):
+        self.proj_state = init_lecun_normal(self.proj_state, device=device)
         nn.init.zeros_(self.proj_state.bias)
-        self.proj_state2 = init_lecun_normal(self.proj_state2)
+        self.proj_state2 = init_lecun_normal(self.proj_state2, device=device)
         nn.init.zeros_(self.proj_state2.bias)
 
     def forward(self, seq, msa, msa_full, pair, xyz_in, state, idx, use_checkpoint=False, motif_mask=None):

--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -223,13 +223,16 @@ class Sampler:
         # Read input dimensions from checkpoint.
         self.d_t1d=self._conf.preprocess.d_t1d
         self.d_t2d=self._conf.preprocess.d_t2d
-        model = RoseTTAFoldModule(**self._conf.model, d_t1d=self.d_t1d, d_t2d=self.d_t2d, T=self._conf.diffuser.T).to(self.device)
+        self._log.info('Creating model...')
+        model = RoseTTAFoldModule(**self._conf.model, d_t1d=self.d_t1d, d_t2d=self.d_t2d, T=self._conf.diffuser.T, device=self.device)
+        self._log.info('...model created')
         if self._conf.logging.inputs:
             pickle_dir = pickle_function_call(model, 'forward', 'inference')
             print(f'pickle_dir: {pickle_dir}')
         model = model.eval()
-        self._log.info(f'Loading checkpoint.')
+        self._log.info('Loading checkpoint...')
         model.load_state_dict(self.ckpt['model_state_dict'], strict=True)
+        self._log.info('...checkpoint loaded')
         return model
 
     def construct_contig(self, target_feats):

--- a/rfdiffusion/util_module.py
+++ b/rfdiffusion/util_module.py
@@ -6,15 +6,15 @@ import copy
 import dgl
 from rfdiffusion.util import base_indices, RTs_by_torsion, xyzs_in_base_frame, rigid_from_3_points
 
-def init_lecun_normal(module):
+def init_lecun_normal(module, device=None):
     def truncated_normal(uniform, mu=0.0, sigma=1.0, a=-2, b=2):
         normal = torch.distributions.normal.Normal(0, 1)
 
         alpha = (a - mu) / sigma
         beta = (b - mu) / sigma
 
-        alpha_normal_cdf = normal.cdf(torch.tensor(alpha))
-        p = alpha_normal_cdf + (normal.cdf(torch.tensor(beta)) - alpha_normal_cdf) * uniform
+        alpha_normal_cdf = normal.cdf(torch.tensor(alpha, device=device))
+        p = alpha_normal_cdf + (normal.cdf(torch.tensor(beta, device=device)) - alpha_normal_cdf) * uniform
 
         v = torch.clamp(2 * p - 1, -1 + 1e-8, 1 - 1e-8)
         x = mu + sigma * np.sqrt(2) * torch.erfinv(v)
@@ -24,20 +24,20 @@ def init_lecun_normal(module):
 
     def sample_truncated_normal(shape):
         stddev = np.sqrt(1.0/shape[-1])/.87962566103423978  # shape[-1] = fan_in
-        return stddev * truncated_normal(torch.rand(shape))
+        return stddev * truncated_normal(torch.rand(shape, device=device))
 
     module.weight = torch.nn.Parameter( (sample_truncated_normal(module.weight.shape)) )
     return module
 
-def init_lecun_normal_param(weight):
+def init_lecun_normal_param(weight, device=None):
     def truncated_normal(uniform, mu=0.0, sigma=1.0, a=-2, b=2):
         normal = torch.distributions.normal.Normal(0, 1)
 
         alpha = (a - mu) / sigma
         beta = (b - mu) / sigma
 
-        alpha_normal_cdf = normal.cdf(torch.tensor(alpha))
-        p = alpha_normal_cdf + (normal.cdf(torch.tensor(beta)) - alpha_normal_cdf) * uniform
+        alpha_normal_cdf = normal.cdf(torch.tensor(alpha, device=device))
+        p = alpha_normal_cdf + (normal.cdf(torch.tensor(beta, device=device)) - alpha_normal_cdf) * uniform
 
         v = torch.clamp(2 * p - 1, -1 + 1e-8, 1 - 1e-8)
         x = mu + sigma * np.sqrt(2) * torch.erfinv(v)
@@ -47,7 +47,7 @@ def init_lecun_normal_param(weight):
 
     def sample_truncated_normal(shape):
         stddev = np.sqrt(1.0/shape[-1])/.87962566103423978  # shape[-1] = fan_in
-        return stddev * truncated_normal(torch.rand(shape))
+        return stddev * truncated_normal(torch.rand(shape, device=device))
 
     weight = torch.nn.Parameter( (sample_truncated_normal(weight.shape)) )
     return weight
@@ -63,10 +63,10 @@ def get_clones(module, N):
 
 class Dropout(nn.Module):
     # Dropout entire row or column
-    def __init__(self, broadcast_dim=None, p_drop=0.15):
+    def __init__(self, broadcast_dim=None, p_drop=0.15, device=None):
         super(Dropout, self).__init__()
         # give ones with probability of 1-p_drop / zeros with p_drop
-        self.sampler = torch.distributions.bernoulli.Bernoulli(torch.tensor([1-p_drop]))
+        self.sampler = torch.distributions.bernoulli.Bernoulli(torch.tensor([1-p_drop], device=device))
         self.broadcast_dim=broadcast_dim
         self.p_drop=p_drop
     def forward(self, x):


### PR DESCRIPTION
The device kwarg here is a common, albeit relatively new pattern. Adding it was a boring traversal of the call graph.

This allows creating models directly on device or even uninitialized. This dramatically speeds up model creation, which matter most for running the end-to-end tests, where the model is separately initialized in a bunch of different processes, and even more especially when trying to run those tests in parallel where torch will overwhelm the CPU.

This allows me to get almost full parallelism speedups on the example script tests on multiple GPUs, whereas previously I was seeing dramatic dropoff (6 GPUs was more than half the time of 1 GPU on a machine with 192 CPU cores).

Of course, with https://github.com/Brium/RFdiffusion/pull/17, that maybe becomes unimportant, but I'd already done this and I think it's just generally an improvement.

Theoretically this should allow us to skip initialization entirely using `torch.nn.utils.skip_init` and just load the weights from a checkpoint, but I found that in practice this did not speed things up (if anything, it was slower). This is perhaps because RFdiffusion is doing some custom initialization that doesn't play nicely with the "meta" device used by `skip_init`. Given no large speedups, I don't think it's worth playing with this more advanced feature.