### PR TITLE
Add biopython to deps

### DIFF
--- a/docker/Dockerfile.rocm-deps-only
+++ b/docker/Dockerfile.rocm-deps-only
@@ -6,9 +6,8 @@ FROM gcmn/dgl:rocm-complete
 
 WORKDIR /pip
 # RFdiffusion deps
-RUN pip install hydra-core pyrsistent e3nn==0.3.3 decorator==5.1.0 \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install hydra-core pyrsistent e3nn==0.3.3 decorator==5.1.0 biopython \
     && rm -rf /pip
-
-ENV PYTHONWARNINGS="ignore::UserWarning,ignore::DeprecationWarning,ignore::PendingDeprecationWarning,ignore::ImportWarning,ignore::ResourceWarning,ignore::FutureWarning"
 
 WORKDIR /


### PR DESCRIPTION
I thought I did this when I added it to the tests in https://github.com/Brium/RFdiffusion/pull/12, but apparently not.

Also cache pip and don't silence Python warnings. The warnings are annoying but actually are informative in some cases. Better not to just blanket silence them.