### PR TITLE
Add option to use `torch.compile`

### DIFF
--- a/config/inference/base.yaml
+++ b/config/inference/base.yaml
@@ -22,6 +22,8 @@ inference:
   trb_save_ckpt_path: null
   schedule_directory_path: null
   model_directory_path: null
+  compile: False
+  compilation_mode: null
 
 contigmap:
   contigs: null

--- a/env/SE3Transformer/se3_transformer/model/basis.py
+++ b/env/SE3Transformer/se3_transformer/model/basis.py
@@ -61,7 +61,6 @@ def get_spherical_harmonics(relative_pos: Tensor, max_degree: int) -> List[Tenso
     return torch.split(sh, [degree_to_dim(d) for d in all_degrees], dim=1)
 
 
-@torch.jit.script
 def get_basis_script(max_degree: int,
                      use_pad_trick: bool,
                      spherical_harmonics: List[Tensor],
@@ -97,7 +96,6 @@ def get_basis_script(max_degree: int,
     return basis
 
 
-@torch.jit.script
 def update_basis_with_fused(basis: Dict[str, Tensor],
                             max_degree: int,
                             use_pad_trick: bool,

--- a/env/SE3Transformer/se3_transformer/model/basis.py
+++ b/env/SE3Transformer/se3_transformer/model/basis.py
@@ -61,6 +61,7 @@ def get_spherical_harmonics(relative_pos: Tensor, max_degree: int) -> List[Tenso
     return torch.split(sh, [degree_to_dim(d) for d in all_degrees], dim=1)
 
 
+@torch.compile
 def get_basis_script(max_degree: int,
                      use_pad_trick: bool,
                      spherical_harmonics: List[Tensor],
@@ -158,6 +159,7 @@ def update_basis_with_fused(basis: Dict[str, Tensor],
     return basis
 
 
+@torch.compiler.disable
 def get_basis(relative_pos: Tensor,
               max_degree: int = 4,
               compute_gradients: bool = False,

--- a/env/SE3Transformer/se3_transformer/model/basis.py
+++ b/env/SE3Transformer/se3_transformer/model/basis.py
@@ -61,7 +61,6 @@ def get_spherical_harmonics(relative_pos: Tensor, max_degree: int) -> List[Tenso
     return torch.split(sh, [degree_to_dim(d) for d in all_degrees], dim=1)
 
 
-@torch.compile
 def get_basis_script(max_degree: int,
                      use_pad_trick: bool,
                      spherical_harmonics: List[Tensor],
@@ -159,7 +158,7 @@ def update_basis_with_fused(basis: Dict[str, Tensor],
     return basis
 
 
-@torch.compiler.disable
+@torch.compiler.disable(recursive=False)
 def get_basis(relative_pos: Tensor,
               max_degree: int = 4,
               compute_gradients: bool = False,

--- a/env/SE3Transformer/se3_transformer/model/layers/convolution.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/convolution.py
@@ -114,7 +114,7 @@ class RadialProfile(nn.Module):
             nn.Linear(mid_dim, num_freq * channels_in * channels_out, bias=False, device=device)
         ]
 
-        self.net = torch.jit.script(nn.Sequential(*[m for m in modules if m is not None]))
+        self.net = nn.Sequential(*[m for m in modules if m is not None])
 
     def forward(self, features: Tensor) -> Tensor:
         return self.net(features)

--- a/env/SE3Transformer/se3_transformer/model/layers/norm.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/norm.py
@@ -32,11 +32,9 @@ from torch.cuda.nvtx import range as nvtx_range
 from se3_transformer.model.fiber import Fiber
 
 
-@torch.jit.script
 def clamped_norm(x, clamp: float):
     return x.norm(p=2, dim=-1, keepdim=True).clamp(min=clamp)
 
-@torch.jit.script
 def rescale(x, norm, new_norm):
     return x / norm * new_norm
 

--- a/env/SE3Transformer/se3_transformer/model/transformer.py
+++ b/env/SE3Transformer/se3_transformer/model/transformer.py
@@ -49,7 +49,7 @@ class Sequential(nn.Sequential):
 
 def get_populated_edge_features(relative_pos: Tensor, edge_features: Optional[Dict[str, Tensor]] = None):
     """ Add relative positions to existing edge features """
-    edge_features = edge_features.copy() if edge_features else {}
+    edge_features = edge_features or {}
     r = relative_pos.norm(dim=-1, keepdim=True)
     if '0' in edge_features:
         edge_features['0'] = torch.cat([edge_features['0'], r[..., None]], dim=1)

--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -104,6 +104,8 @@ class Sampler:
             self.assemble_config_from_chk()
             # Now actually load the model weights into RF
             self.model = self.load_model()
+            if conf.inference.compile:
+                self.model.compile(mode=conf.inference.compilation_mode)
         else:
             self.assemble_config_from_chk()
 


### PR DESCRIPTION
This adds options to use `torch.compile` and specify the mode to the inference config.

I removed the usage of `torch.jit.script` since having two compilation mechanisms seemed like asking for trouble. This means that when `inference.compile` is not set, there won't be any compilation of those functions. That's maybe undesirable, but I wasn't able to detect any performance impact. We could consider instead something like a `maybe_torchscript` decorator that uses `torch.jit.script` iff `torch.compile` isn't being used (there's a `torch.compiler.is_compiling()` you can check). I also considered adding explicit `torch.compile` calls there, but it seems surprising to have a configuration option for turning compilation on and then doing compilation even when that option is off. In particular, `torch.compile` sometimes doesn't work at all, so having it get used unconditionally is a bit rude.

With this option off, the max RMSD is still 0.0 (despite disabling `torch.jit.script`). Actually enabling `torch.compile` changes the output somewhat and will require a more semantic evaluation of the outputs. I also need to figure out the best way to integrate compilation into the testing.