### PR TITLE
Wrapper for `nvtx.range` that noops under compilation

### DIFF
--- a/env/SE3Transformer/se3_transformer/model/basis.py
+++ b/env/SE3Transformer/se3_transformer/model/basis.py
@@ -30,7 +30,6 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from se3_transformer.model.profiling import maybe_nvtx_range
-from se3_transformer.model.profiling import maybe_nvtx_range
 
 from se3_transformer.runtime.utils import degree_to_dim
 

--- a/env/SE3Transformer/se3_transformer/model/basis.py
+++ b/env/SE3Transformer/se3_transformer/model/basis.py
@@ -29,7 +29,8 @@ import e3nn.o3 as o3
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.profiling import maybe_nvtx_range
+from se3_transformer.model.profiling import maybe_nvtx_range
 
 from se3_transformer.runtime.utils import degree_to_dim
 
@@ -164,13 +165,13 @@ def get_basis(relative_pos: Tensor,
               compute_gradients: bool = False,
               use_pad_trick: bool = False,
               amp: bool = False) -> Dict[str, Tensor]:
-    with nvtx_range('spherical harmonics'):
+    with maybe_nvtx_range('spherical harmonics'):
         spherical_harmonics = get_spherical_harmonics(relative_pos, max_degree)
-    with nvtx_range('CB coefficients'):
+    with maybe_nvtx_range('CB coefficients'):
         clebsch_gordon = get_all_clebsch_gordon(max_degree, relative_pos.device)
 
     with torch.autograd.set_grad_enabled(compute_gradients):
-        with nvtx_range('bases'):
+        with maybe_nvtx_range('bases'):
             basis = get_basis_script(max_degree=max_degree,
                                      use_pad_trick=use_pad_trick,
                                      spherical_harmonics=spherical_harmonics,

--- a/env/SE3Transformer/se3_transformer/model/layers/attention.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/attention.py
@@ -34,7 +34,7 @@ from se3_transformer.model.fiber import Fiber
 from se3_transformer.model.layers.convolution import ConvSE3, ConvSE3FuseLevel
 from se3_transformer.model.layers.linear import LinearSE3
 from se3_transformer.runtime.utils import degree_to_dim, aggregate_residual, unfuse_features
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.profiling import maybe_nvtx_range
 
 
 class AttentionSE3(nn.Module):
@@ -64,8 +64,8 @@ class AttentionSE3(nn.Module):
             query: Dict[str, Tensor],  # node features
             graph: DGLGraph
     ):
-        with nvtx_range('AttentionSE3'):
-            with nvtx_range('reshape keys and queries'):
+        with maybe_nvtx_range('AttentionSE3'):
+            with maybe_nvtx_range('reshape keys and queries'):
                 if isinstance(key, Tensor):
                     # case where features of all types are fused
                     key = key.reshape(key.shape[0], self.num_heads, -1)
@@ -77,14 +77,14 @@ class AttentionSE3(nn.Module):
                     key = self.key_fiber.to_attention_heads(key, self.num_heads)
                     query = self.key_fiber.to_attention_heads(query, self.num_heads)
 
-            with nvtx_range('attention dot product + softmax'):
+            with maybe_nvtx_range('attention dot product + softmax'):
                 # Compute attention weights (softmax of inner product between key and query)
                 edge_weights = dgl.ops.e_dot_v(graph, key, query).squeeze(-1)
                 edge_weights = edge_weights / np.sqrt(self.key_fiber.num_features)
                 edge_weights = edge_softmax(graph, edge_weights)
                 edge_weights = edge_weights[..., None, None]
 
-            with nvtx_range('weighted sum'):
+            with maybe_nvtx_range('weighted sum'):
                 if isinstance(value, Tensor):
                     # features of all types are fused
                     v = value.view(value.shape[0], self.num_heads, -1, value.shape[-1])
@@ -155,12 +155,12 @@ class AttentionBlockSE3(nn.Module):
             graph: DGLGraph,
             basis: Dict[str, Tensor]
     ):
-        with nvtx_range('AttentionBlockSE3'):
-            with nvtx_range('keys / values'):
+        with maybe_nvtx_range('AttentionBlockSE3'):
+            with maybe_nvtx_range('keys / values'):
                 fused_key_value = self.to_key_value(node_features, edge_features, graph, basis)
                 key, value = self._get_key_value_from_fused(fused_key_value)
 
-            with nvtx_range('queries'):
+            with maybe_nvtx_range('queries'):
                 query = self.to_query(node_features)
 
             z = self.attention(value, key, query, graph)

--- a/env/SE3Transformer/se3_transformer/model/layers/convolution.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/convolution.py
@@ -32,7 +32,7 @@ import torch.nn as nn
 import torch.utils.checkpoint
 from dgl import DGLGraph
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.profiling import maybe_nvtx_range
 
 from se3_transformer.model.fiber import Fiber
 from se3_transformer.runtime.utils import degree_to_dim, unfuse_features
@@ -147,10 +147,10 @@ class VersatileConvSE3(nn.Module):
                                          device=device)
 
     def forward(self, features: Tensor, invariant_edge_feats: Tensor, basis: Tensor):
-        with nvtx_range(f'VersatileConvSE3'):
+        with maybe_nvtx_range(f'VersatileConvSE3'):
             num_edges = features.shape[0]
             in_dim = features.shape[2]
-            with nvtx_range(f'RadialProfile'):
+            with maybe_nvtx_range(f'RadialProfile'):
                 radial_weights = self.radial_func(invariant_edge_feats) \
                     .view(-1, self.channels_out, self.channels_in * self.freq_sum)
 
@@ -290,7 +290,7 @@ class ConvSE3(nn.Module):
             graph: DGLGraph,
             basis: Dict[str, Tensor]
     ):
-        with nvtx_range(f'ConvSE3'):
+        with maybe_nvtx_range(f'ConvSE3'):
             invariant_edge_feats = edge_feats['0'].squeeze(-1)
             src, dst = graph.edges()
             out = {}
@@ -345,13 +345,13 @@ class ConvSE3(nn.Module):
 
             for degree_out in self.fiber_out.degrees:
                 if self.self_interaction and str(degree_out) in self.to_kernel_self:
-                    with nvtx_range(f'self interaction'):
+                    with maybe_nvtx_range(f'self interaction'):
                         dst_features = node_feats[str(degree_out)][dst]
                         kernel_self = self.to_kernel_self[str(degree_out)]
                         out[str(degree_out)] = out[str(degree_out)] + kernel_self @ dst_features
 
                 if self.pool:
-                    with nvtx_range(f'pooling'):
+                    with maybe_nvtx_range(f'pooling'):
                         if isinstance(out, dict):
                             out[str(degree_out)] = dgl.ops.copy_e_sum(graph, out[str(degree_out)])
                         else:

--- a/env/SE3Transformer/se3_transformer/model/layers/norm.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/norm.py
@@ -27,7 +27,7 @@ from typing import Dict
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.profiling import maybe_nvtx_range
 
 from se3_transformer.model.fiber import Fiber
 
@@ -66,7 +66,7 @@ class NormSE3(nn.Module):
             })
 
     def forward(self, features: Dict[str, Tensor], *args, **kwargs) -> Dict[str, Tensor]:
-        with nvtx_range('NormSE3'):
+        with maybe_nvtx_range('NormSE3'):
             output = {}
             if hasattr(self, 'group_norm'):
                 # Compute per-degree norms of features

--- a/env/SE3Transformer/se3_transformer/model/profiling.py
+++ b/env/SE3Transformer/se3_transformer/model/profiling.py
@@ -1,0 +1,14 @@
+import contextlib
+
+import torch
+
+
+def maybe_nvtx_range(msg, *args, **kwargs):
+    """Creates an NVTX range context if not compiling, but skips it under compilation.
+
+    nvtx.range causes a graph break under torch.compile, so we disable it.
+    """
+    if torch.compiler.is_compiling():
+        return contextlib.nullcontext()
+    else:
+        return torch.cuda.nvtx.range(msg, *args, **kwargs)


### PR DESCRIPTION
`nvtx.range` unfortunately forces a graph break in the compilation graph, so we noop it when under `torch.compile`.