### PR TITLE
Script for benchmarking inference steps

### DIFF
--- a/config/inference/base.yaml
+++ b/config/inference/base.yaml
@@ -24,6 +24,7 @@ inference:
   model_directory_path: null
   compile: False
   compilation_mode: null
+  require_gpu: False
 
 contigmap:
   contigs: null

--- a/config/inference/benchmark.yaml
+++ b/config/inference/benchmark.yaml
@@ -8,7 +8,7 @@ benchmark:
   warmup_designs: 1
   warmup_steps: 1
   benchmark_steps: 3
-  require_gpu: True
 
 inference:
   num_designs: 1
+  require_gpu: True

--- a/config/inference/benchmark.yaml
+++ b/config/inference/benchmark.yaml
@@ -9,3 +9,6 @@ benchmark:
   warmup_steps: 1
   benchmark_steps: 3
   require_gpu: True
+
+inference:
+  num_designs: 1

--- a/config/inference/benchmark.yaml
+++ b/config/inference/benchmark.yaml
@@ -1,0 +1,11 @@
+# Config for running benchmarks.
+
+defaults:
+  - base
+  - _self_
+
+benchmark:
+  warmup_designs: 1
+  warmup_steps: 1
+  benchmark_steps: 3
+  require_gpu: True

--- a/rfdiffusion/inference/benchmark_step.py
+++ b/rfdiffusion/inference/benchmark_step.py
@@ -29,9 +29,10 @@ def benchmark_inference_step(conf: HydraConfig) -> None:
     # Initialize sampler and target/contig.
     sampler = iu.sampler_selector(conf)
     total_steps = bench_conf.warmup_steps + bench_conf.benchmark_steps
+    sampler_steps = sampler.t_step_input - sampler.inf_conf.final_step + 1
     assert (
-        sampler.t_step_input >= total_steps
-    ), f"Sampler total steps {sampler.t_step_input} is less than requested total steps {total_steps}"
+        sampler_steps >= total_steps
+    ), f"Sampler total steps {sampler_steps} is less than requested total steps {total_steps}"
 
     # Loop over number of designs to sample.
     design_startnum = sampler.inf_conf.design_startnum

--- a/rfdiffusion/inference/benchmark_step.py
+++ b/rfdiffusion/inference/benchmark_step.py
@@ -1,0 +1,94 @@
+import time
+import torch
+import logging
+from rfdiffusion.inference import utils as iu
+from hydra.core.hydra_config import HydraConfig
+import statistics
+
+
+def benchmark_inference_step(conf: HydraConfig) -> None:
+    """Benchmarks individual steps of inference.
+
+    This seeks to evaluate the steady-state performance of the key inference
+    workload while avoiding running all the steps. This will not capture the
+    contributions of overhead from initialization but should still give a good
+    idea of overall perforamce on large workloads without having to run the
+    whole thing. It expects a config as defined in
+    config/inference/benchmark.yaml
+    """
+    log = logging.getLogger(__name__)
+
+    bench_conf = conf.benchmark
+
+    if conf.inference.deterministic:
+        conf.inference.random_seed = conf.inference.random_seed or 0
+        iu.make_deterministic(conf.inference.random_seed)
+
+    # Check for available GPU and print result of check
+    if torch.cuda.is_available():
+        log.info("GPU is available")
+        device_name = torch.cuda.get_device_name(torch.cuda.current_device())
+        log.info(
+            f"Found GPU with device_name {device_name}. Will run RFdiffusion on {device_name}"
+        )
+    elif bench_conf.require_gpu:
+        raise RuntimeError(
+            "No GPU detected. Aborting because benchmark.require_gpu is True."
+            " Set to False to allow CPU benchmarking."
+        )
+    else:
+        log.info(
+            "////////////////////////////////////////////////"
+            "///// NO GPU DETECTED! Falling back to CPU /////"
+            "////////////////////////////////////////////////"
+        )
+
+    # Initialize sampler and target/contig.
+    sampler = iu.sampler_selector(conf)
+    total_steps = bench_conf.warmup_steps + bench_conf.benchmark_steps
+    assert (
+        sampler.t_step_input >= total_steps
+    ), f"Sampler total steps {sampler.t_step_input} is less than requested total steps {total_steps}"
+
+    # Loop over number of designs to sample.
+    design_startnum = sampler.inf_conf.design_startnum
+    total_designs = sampler.inf_conf.num_designs + bench_conf.warmup_designs
+
+    times = []
+    for i_des in range(design_startnum, design_startnum + total_designs):
+        if conf.inference.random_seed is not None:
+            iu.seed_rngs(conf.inference.random_seed + i_des)
+
+        log.info(f"Making design {i_des}")
+
+        x_init, seq_init = sampler.sample_init()
+
+        x_t = torch.clone(x_init)
+        seq_t = torch.clone(seq_init)
+        t = int(sampler.t_step_input)
+        for _ in range(bench_conf.warmup_steps):
+            _, x_t, seq_t, _ = sampler.sample_step(
+                t=t, x_t=x_t, seq_init=seq_t, final_step=sampler.inf_conf.final_step
+            )
+            t -= 1
+
+        torch.cuda.synchronize()
+        start_time = time.perf_counter()
+        for _ in range(bench_conf.benchmark_steps):
+            _, x_t, seq_t, _ = sampler.sample_step(
+                t=t, x_t=x_t, seq_init=seq_t, final_step=sampler.inf_conf.final_step
+            )
+            t -= 1
+        torch.cuda.synchronize()
+        elapsed_time = time.perf_counter() - start_time
+        time_per_step = elapsed_time / bench_conf.benchmark_steps
+
+        times.append(time_per_step)
+
+    times = times[bench_conf.warmup_designs :]
+    times = sorted(times)
+    median_time_per_step = statistics.median(times)
+    print(
+        f"Median time per step: {median_time_per_step*1000:.0f}ms ({times[0]*1000:.0f}ms-{times[-1]*1000:.0f}ms): ",
+        ",".join([f"{t*1000:.0f}" for t in times]),
+    )

--- a/rfdiffusion/inference/benchmark_step.py
+++ b/rfdiffusion/inference/benchmark_step.py
@@ -68,6 +68,7 @@ def benchmark_inference_step(conf: HydraConfig) -> None:
         time_per_step = elapsed_time / bench_conf.benchmark_steps
 
         times.append(time_per_step)
+        print(f"Time per step: {time_per_step*1000:.0f}ms")
 
     times = times[bench_conf.warmup_designs :]
     times = sorted(times)

--- a/rfdiffusion/inference/benchmark_step.py
+++ b/rfdiffusion/inference/benchmark_step.py
@@ -24,24 +24,7 @@ def benchmark_inference_step(conf: HydraConfig) -> None:
         conf.inference.random_seed = conf.inference.random_seed or 0
         iu.make_deterministic(conf.inference.random_seed)
 
-    # Check for available GPU and print result of check
-    if torch.cuda.is_available():
-        log.info("GPU is available")
-        device_name = torch.cuda.get_device_name(torch.cuda.current_device())
-        log.info(
-            f"Found GPU with device_name {device_name}. Will run RFdiffusion on {device_name}"
-        )
-    elif bench_conf.require_gpu:
-        raise RuntimeError(
-            "No GPU detected. Aborting because benchmark.require_gpu is True."
-            " Set to False to allow CPU benchmarking."
-        )
-    else:
-        log.info(
-            "////////////////////////////////////////////////"
-            "///// NO GPU DETECTED! Falling back to CPU /////"
-            "////////////////////////////////////////////////"
-        )
+    iu.find_gpu(required=conf.inference.require_gpu)
 
     # Initialize sampler and target/contig.
     sampler = iu.sampler_selector(conf)

--- a/rfdiffusion/inference/run.py
+++ b/rfdiffusion/inference/run.py
@@ -6,8 +6,6 @@ import logging
 from rfdiffusion.util import writepdb_multi, writepdb
 from rfdiffusion.inference import utils as iu
 from hydra.core.hydra_config import HydraConfig
-import numpy as np
-import random
 import glob
 
 
@@ -50,7 +48,7 @@ def run_inference(conf: HydraConfig) -> None:
         if conf.inference.random_seed is not None:
             iu.seed_rngs(conf.inference.random_seed + i_des)
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         out_prefix = f"{sampler.inf_conf.output_prefix}_{i_des}"
         log.info(f"Making design {out_prefix}")
         if sampler.inf_conf.cautious and os.path.exists(out_prefix + ".pdb"):
@@ -128,7 +126,7 @@ def run_inference(conf: HydraConfig) -> None:
             device=torch.cuda.get_device_name(torch.cuda.current_device())
             if torch.cuda.is_available()
             else "CPU",
-            time=time.time() - start_time,
+            time=time.perf_counter() - start_time,
         )
         if hasattr(sampler, "contig_map"):
             for key, value in sampler.contig_map.get_mappings().items():
@@ -165,4 +163,4 @@ def run_inference(conf: HydraConfig) -> None:
                 chain_ids=sampler.chain_idx,
             )
 
-        log.info(f"Finished design in {(time.time()-start_time)/60:.2f} minutes")
+        log.info(f"Finished design in {(time.perf_counter()-start_time)/60:.2f} minutes")

--- a/rfdiffusion/inference/run.py
+++ b/rfdiffusion/inference/run.py
@@ -16,15 +16,7 @@ def run_inference(conf: HydraConfig) -> None:
         conf.inference.random_seed = conf.inference.random_seed or 0
         iu.make_deterministic(conf.inference.random_seed)
 
-    # Check for available GPU and print result of check
-    if torch.cuda.is_available():
-        log.info("GPU is available")
-        device_name = torch.cuda.get_device_name(torch.cuda.current_device())
-        log.info(f"Found GPU with device_name {device_name}. Will run RFdiffusion on {device_name}")
-    else:
-        log.info("////////////////////////////////////////////////"
-                 "///// NO GPU DETECTED! Falling back to CPU /////"
-                 "////////////////////////////////////////////////")
+    iu.find_gpu(conf.inference.require_gpu)
 
     # Initialize sampler and target/contig.
     sampler = iu.sampler_selector(conf)

--- a/rfdiffusion/inference/utils.py
+++ b/rfdiffusion/inference/utils.py
@@ -17,6 +17,7 @@ import glob
 #### Functions which can be called outside of Denoiser ####
 ###########################################################
 
+logger = logging.getLogger(__name__)
 
 def get_next_frames(xt, px0, t, diffuser, so3_type, diffusion_mask, noise_scale=1.0):
     """
@@ -1025,3 +1026,19 @@ def seed_rngs(seed=0):
     torch.manual_seed(seed)
     np.random.seed(seed)
     random.seed(seed)
+
+def find_gpu(required=False):
+    if torch.cuda.is_available():
+        logger.info("GPU is available")
+        device_name = torch.cuda.get_device_name(torch.cuda.current_device())
+        logger.info(
+            f"Found GPU with device_name {device_name}. Will run RFdiffusion on {device_name}"
+        )
+    elif required:
+        raise RuntimeError("No GPU detected. Aborting because GPU was marked required.")
+    else:
+        logger.info(
+            "////////////////////////////////////////////////"
+            "///// NO GPU DETECTED! Falling back to CPU /////"
+            "////////////////////////////////////////////////"
+        )

--- a/scripts/benchmark_inference_step.py
+++ b/scripts/benchmark_inference_step.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+"""
+Script to benchmark inference steps.
+
+Accepts the same options as run_inference.py with the addition of benchmark-specific options in benchmark.yaml
+"""
+import hydra
+from hydra.core.hydra_config import HydraConfig
+
+from rfdiffusion.inference.benchmark_step import benchmark_inference_step
+
+
+@hydra.main(version_base=None, config_path="../config/inference", config_name="benchmark")
+def main(conf: HydraConfig):
+    return benchmark_inference_step(conf)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This focuses on the step level because it allows us to get results much faster and evaluate inference time separately from initialization overhead. The idea is that this is likely actually a better proxy for performance when creating many designs than running inference to design completion. It's also about 50 times faster, which is nice for iterative development.

I cleaned up a couple things in the regular inference run as well as I was adapting it.