### PR TITLE
Use pip for se3transformer install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,12 +2,13 @@
 .github/
 docker/
 img/
-examples/ppi_scaffolds/
+*.venv
 
 **/*.py[cod]
 rfdiffusion.egg-info
 __pycache__/
 
+models/
 schedules/
 outputs/
 test_outputs/

--- a/docker/Dockerfile.rocm-complete
+++ b/docker/Dockerfile.rocm-complete
@@ -9,7 +9,7 @@ ENV RFDIFFUSION_HOME="${RFDIFFUSION_HOME}"
 COPY . "${RFDIFFUSION_HOME}"
 WORKDIR "${RFDIFFUSION_HOME}"
 RUN cd env/SE3Transformer \
-    && python setup.py develop \
+    && pip install -e . \
     && cd ../.. \
     && pip install -e .
 


### PR DESCRIPTION
Using setup.py directly is discouraged and harder to deal with (e.g. uninstalling). Pip uses setup.py under the hood but also does a bunch of tracking. I don't think there's really any disadvantage to switching here.

I also added some things to the dockerignore that I noticed were missing because the context was way bigger than it should be.