### PR TITLE
Make device specification more flexible

### DIFF
--- a/config/inference/base.yaml
+++ b/config/inference/base.yaml
@@ -26,7 +26,7 @@ inference:
   cyc_chains: 'a'
   compile: False
   compilation_mode: null
-  require_gpu: False
+  device: "auto"
 
 contigmap:
   contigs: null

--- a/config/inference/benchmark.yaml
+++ b/config/inference/benchmark.yaml
@@ -11,4 +11,4 @@ benchmark:
 
 inference:
   num_designs: 1
-  require_gpu: True
+  device: "cuda"

--- a/rfdiffusion/diffusion.py
+++ b/rfdiffusion/diffusion.py
@@ -16,6 +16,7 @@ import time
 
 torch.set_printoptions(sci_mode=False)
 
+logger = logging.getLogger(__name__)
 
 def get_beta_schedule(T, b0, bT, schedule_type, schedule_params={}, inference=False):
     """
@@ -41,8 +42,9 @@ def get_beta_schedule(T, b0, bT, schedule_type, schedule_params={}, inference=Fa
     alphabar_t_schedule = torch.cumprod(alpha_schedule, dim=0)
 
     if inference:
-        print(
-            f"With this beta schedule ({schedule_type} schedule, beta_0 = {round(b0, 3)}, beta_T = {round(bT,3)}), alpha_bar_T = {alphabar_t_schedule[-1]}"
+        logger.info(
+            f"With this beta schedule ({schedule_type} schedule, beta_0 = {round(b0, 3)},"
+            f" beta_T = {round(bT,3)}), alpha_bar_T = {alphabar_t_schedule[-1]}"
         )
 
     return schedule, alpha_schedule, alphabar_t_schedule
@@ -569,6 +571,7 @@ class Diffuser:
             b_T (float, required): Ending variance for Euclidean schedule
 
         """
+        self._log = logging.getLogger(__name__)
         self.T = T
         self.b_0 = b_0
         self.b_T = b_T
@@ -595,7 +598,7 @@ class Diffuser:
             self.T, b_0, b_T, schedule_type=schedule_type, **schedule_kwargs
         )
 
-        print("Successful diffuser __init__")
+        self._log.debug("Successful diffuser __init__")
 
     def diffuse_pose(
         self,

--- a/rfdiffusion/inference/benchmark_step.py
+++ b/rfdiffusion/inference/benchmark_step.py
@@ -24,8 +24,6 @@ def benchmark_inference_step(conf: HydraConfig) -> None:
         conf.inference.random_seed = conf.inference.random_seed or 0
         iu.make_deterministic(conf.inference.random_seed)
 
-    iu.find_gpu(required=conf.inference.require_gpu)
-
     # Initialize sampler and target/contig.
     sampler = iu.sampler_selector(conf)
     total_steps = bench_conf.warmup_steps + bench_conf.benchmark_steps

--- a/rfdiffusion/inference/benchmark_step.py
+++ b/rfdiffusion/inference/benchmark_step.py
@@ -16,7 +16,7 @@ def benchmark_inference_step(conf: HydraConfig) -> None:
     whole thing. It expects a config as defined in
     config/inference/benchmark.yaml
     """
-    log = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
     bench_conf = conf.benchmark
 
@@ -43,7 +43,7 @@ def benchmark_inference_step(conf: HydraConfig) -> None:
         if conf.inference.random_seed is not None:
             iu.seed_rngs(conf.inference.random_seed + i_des)
 
-        log.info(f"Making design {i_des}")
+        logger.info(f"Making design {i_des}")
 
         x_init, seq_init = sampler.sample_init()
 
@@ -68,7 +68,7 @@ def benchmark_inference_step(conf: HydraConfig) -> None:
         time_per_step = elapsed_time / bench_conf.benchmark_steps
 
         times.append(time_per_step)
-        print(f"Time per step: {time_per_step*1000:.0f}ms")
+        logger.info(f"Time per step: {time_per_step*1000:.0f}ms")
 
     times = times[bench_conf.warmup_designs :]
     times = sorted(times)

--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -47,6 +47,7 @@ class Sampler:
 
         """
         self._log = logging.getLogger(__name__)
+        self._warned_hotspots = False
         if torch.cuda.is_available():
             self.device = torch.device('cuda')
         else:
@@ -65,12 +66,12 @@ class Sampler:
         else:
             model_directory = f"{SCRIPT_DIR}/../../models"
 
-        print(f"Reading models from {model_directory}")
+        self._log.info(f"Reading models from {model_directory}")
 
         # Initialize inference only helper objects to Sampler
         if conf.inference.ckpt_override_path is not None:
             self.ckpt_path = conf.inference.ckpt_override_path
-            print("WARNING: You're overriding the checkpoint path from the defaults. Check that the model you're providing can run with the inputs you're providing.")
+            self._log.warning("You're overriding the checkpoint path from the defaults. Check that the model you're providing can run with the inputs you're providing.")
         else:
             if conf.contigmap.inpaint_seq is not None or conf.contigmap.provide_seq is not None or conf.contigmap.inpaint_str:
                 # use model trained for inpaint_seq
@@ -164,6 +165,7 @@ class Sampler:
         else:
             self.t_step_input = int(self.diffuser_conf.T)
 
+
     @property
     def T(self):
         '''
@@ -178,8 +180,7 @@ class Sampler:
     def load_checkpoint(self) -> None:
         """Loads RF checkpoint, from which config can be generated."""
         self._log.info(f'Reading checkpoint from {self.ckpt_path}')
-        print('This is inf_conf.ckpt_path')
-        print(self.ckpt_path)
+        self._log.debug(f'inf_conf.ckpt_path={self.ckpt_path}')
         self.ckpt  = torch.load(
             self.ckpt_path, map_location=self.device, weights_only=True)
 
@@ -202,12 +203,12 @@ class Sampler:
         overrides = []
         if HydraConfig.initialized():
             overrides = HydraConfig.get().overrides.task
-        print("Assembling -model, -diffuser and -preprocess configs from checkpoint")
+        self._log.info("Assembling -model, -diffuser and -preprocess configs from checkpoint")
 
         for cat in ['model','diffuser','preprocess']:
             for key in self._conf[cat]:
                 try:
-                    print(f"USING MODEL CONFIG: self._conf[{cat}][{key}] = {self.ckpt['config_dict'][cat][key]}")
+                    self._log.debug(f"USING MODEL CONFIG: self._conf[{cat}][{key}] = {self.ckpt['config_dict'][cat][key]}")
                     self._conf[cat][key] = self.ckpt['config_dict'][cat][key]
                 except:
                     pass
@@ -215,7 +216,7 @@ class Sampler:
         # add overrides back in again
         for override in overrides:
             if override.split(".")[0] in ['model','diffuser','preprocess']:
-                print(f'WARNING: You are changing {override.split("=")[0]} from the value this model was trained with. Are you sure you know what you are doing?')
+                self._log.warning(f'You are changing {override.split("=")[0]} from the value this model was trained with. Are you sure you know what you are doing?')
                 mytype = type(self._conf[override.split(".")[0]][override.split(".")[1].split("=")[0]])
                 self._conf[override.split(".")[0]][override.split(".")[1].split("=")[0]] = mytype(override.split("=")[1])
 
@@ -553,8 +554,12 @@ class Sampler:
         if self.preprocess_conf.d_t1d >= 24: # add hotspot residues
             hotspot_tens = torch.zeros(L).float()
             if self.ppi_conf.hotspot_res is None:
-                print("WARNING: you're using a model trained on complexes and hotspot residues, without specifying hotspots.\
-                         If you're doing monomer diffusion this is fine")
+                if not self._warned_hotspots:
+                    self._log.warning(
+                        "You're using a model trained on complexes and hotspot residues, without"
+                         " specifying hotspots. If you're doing monomer diffusion this is fine"
+                    )
+                    self._warned_hotspots = True
                 hotspot_idx=[]
             else:
                 hotspots = [(i[0],int(i[1:])) for i in self.ppi_conf.hotspot_res]

--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -48,10 +48,7 @@ class Sampler:
         """
         self._log = logging.getLogger(__name__)
         self._warned_hotspots = False
-        if torch.cuda.is_available():
-            self.device = torch.device('cuda')
-        else:
-            self.device = torch.device('cpu')
+        self.device = iu.get_device(conf.inference.device)
         needs_model_reload = not self.initialized or conf.inference.ckpt_override_path != self._conf.inference.ckpt_override_path
 
         # Assign config to Sampler

--- a/rfdiffusion/inference/profile_step.py
+++ b/rfdiffusion/inference/profile_step.py
@@ -24,8 +24,6 @@ def profile_inference_step(conf: HydraConfig) -> None:
         conf.inference.random_seed = conf.inference.random_seed or 0
         iu.make_deterministic(conf.inference.random_seed)
 
-    iu.find_gpu(required=conf.inference.require_gpu)
-
     # Initialize sampler and target/contig.
     sampler = iu.sampler_selector(conf)
     total_steps = (

--- a/rfdiffusion/inference/run.py
+++ b/rfdiffusion/inference/run.py
@@ -16,8 +16,6 @@ def run_inference(conf: HydraConfig) -> None:
         conf.inference.random_seed = conf.inference.random_seed or 0
         iu.make_deterministic(conf.inference.random_seed)
 
-    iu.find_gpu(conf.inference.require_gpu)
-
     # Initialize sampler and target/contig.
     sampler = iu.sampler_selector(conf)
 
@@ -115,9 +113,9 @@ def run_inference(conf: HydraConfig) -> None:
         trb = dict(
             config=OmegaConf.to_container(sampler._conf, resolve=True),
             plddt=plddt_stack.cpu().numpy(),
-            device=torch.cuda.get_device_name(torch.cuda.current_device())
-            if torch.cuda.is_available()
-            else "CPU",
+            device=torch.cuda.get_device_name(sampler.device)
+            if sampler.device.type == "cuda"
+            else sampler.device.type,
             time=time.perf_counter() - start_time,
         )
         if hasattr(sampler, "contig_map"):
@@ -155,4 +153,4 @@ def run_inference(conf: HydraConfig) -> None:
                 chain_ids=sampler.chain_idx,
             )
 
-        log.info(f"Finished design in {(time.perf_counter()-start_time)/60:.2f} minutes")
+        log.info(f"Finished design in {(time.perf_counter()-start_time):.0f} seconds")

--- a/rfdiffusion/inference/utils.py
+++ b/rfdiffusion/inference/utils.py
@@ -399,7 +399,7 @@ class Denoise:
 
         # check for NaN's
         if torch.isnan(Ca_grads).any():
-            print("WARNING: NaN in potential gradients, replacing with zero grad.")
+            self._log.warning("NaN in potential gradients, replacing with zero grad.")
             Ca_grads[:] = 0
 
         return Ca_grads
@@ -690,6 +690,7 @@ class BlockAdjacency:
              conf.inference.num_designs for sanity checking
         """
 
+        self._log = logging.getLogger(__name__)
         self.conf=conf
         # This is either a list or a path to .txt file with list of scaffolds
         # We need normal Python objects at this point. e.g. OmegaConf ListConfig
@@ -753,8 +754,8 @@ class BlockAdjacency:
         self.num_designs = conf.inference.num_designs
 
         if len(self.scaffold_list) > self.num_designs:
-            print(
-                "WARNING: Scaffold set is bigger than num_designs, so not every scaffold type will be sampled"
+            self._log.warning(
+                "Scaffold set is bigger than num_designs, so not every scaffold type will be sampled"
             )
 
         # for tracking number of designs
@@ -891,7 +892,7 @@ class BlockAdjacency:
             self.item_n += 1
         else:
             item = random.choice(self.scaffold_list)
-        print("Scaffold constrained based on file: ", item)
+        self._log.info(f"Scaffold constrained based on file: {item}")
         # load files
         ss, adj = self.get_ss_adj(item)
         adj_orig = torch.clone(adj)
@@ -1017,7 +1018,7 @@ def ss_from_contig(ss_masks: dict):
     return ss
 
 def make_deterministic(seed=0):
-    print(f"WARNING: Forcing deterministic algorithms. This may affect performance")
+    logger.warning(f"Forcing deterministic algorithms. This may affect performance")
     torch.use_deterministic_algorithms(True)
     torch._C._jit_set_profiling_executor(False)
     torch._C._jit_set_profiling_mode(False)
@@ -1032,7 +1033,7 @@ def seed_rngs(seed=0):
 
 def find_gpu(required=False):
     if torch.cuda.is_available():
-        logger.info("GPU is available")
+        logger.debug("GPU is available")
         device_name = torch.cuda.get_device_name(torch.cuda.current_device())
         logger.info(
             f"Found GPU with device_name {device_name}. Will run RFdiffusion on {device_name}"

--- a/rfdiffusion/inference/utils.py
+++ b/rfdiffusion/inference/utils.py
@@ -1031,18 +1031,26 @@ def seed_rngs(seed=0):
     np.random.seed(seed)
     random.seed(seed)
 
-def find_gpu(required=False):
-    if torch.cuda.is_available():
-        logger.debug("GPU is available")
-        device_name = torch.cuda.get_device_name(torch.cuda.current_device())
+def get_device(device="auto"):
+    if device == "auto":
+        if torch.cuda.is_available():
+            logger.debug("GPU is available")
+            device = "cuda"
+        else:
+            logger.warning(
+                "////////////////////////////////////////////////"
+                "///// NO GPU DETECTED! Falling back to CPU /////"
+                "////////////////////////////////////////////////"
+            )
+            device = "cpu"
+
+    device = torch.device(device)
+
+    if device.type == "cpu":
+        logger.info("Will run RFdiffusion on CPU")
+    else:
+        device_name = torch.cuda.get_device_name(device)
         logger.info(
             f"Found GPU with device_name {device_name}. Will run RFdiffusion on {device_name}"
         )
-    elif required:
-        raise RuntimeError("No GPU detected. Aborting because GPU was marked required.")
-    else:
-        logger.info(
-            "////////////////////////////////////////////////"
-            "///// NO GPU DETECTED! Falling back to CPU /////"
-            "////////////////////////////////////////////////"
-        )
+    return device


### PR DESCRIPTION
This way you can explicitly request CPU or GPU (or perhaps in the future
XPU). The default is still to automatically use a GPU if available.

Only the [last commit](https://github.com/Brium/RFdiffusion/pull/35/commits/de211920debe9c61d289b6fac39ff99154d3fa02) is part of this PR.