### PR TITLE
Don't do unnecessary chain break finding

### DIFF
--- a/rfdiffusion/Embeddings.py
+++ b/rfdiffusion/Embeddings.py
@@ -26,20 +26,19 @@ class PositionalEncoding2D(nn.Module):
         seqsep = idx[:,None,:] - idx[:,:,None] # (B, L, L)
         #
 
-
-        # adding support for multi-chain cyclic
-        # find chain breaks and label chain ids
-        breaks = find_breaks(idx.squeeze().cpu().numpy(), thresh=35)  # NOTE: Hard coded threshold for defining chain breaks here
-                                                                      #       Typical jump for chainbreaks is +200
-                                                                      #       Assumes monotonically increasing absolute IDX
-
-        chainids = np.zeros_like(idx.squeeze().cpu().numpy())
-        for i, b in enumerate(breaks):
-            chainids[b:] = i+1
-        chainids = torch.from_numpy(chainids).to(device=idx.device)
-
         # cyclic peptide
         if cyclize is not None:
+            # adding support for multi-chain cyclic
+            # find chain breaks and label chain ids
+            breaks = find_breaks(idx.squeeze().cpu().numpy(), thresh=35)  # NOTE: Hard coded threshold for defining chain breaks here
+                                                                        #       Typical jump for chainbreaks is +200
+                                                                        #       Assumes monotonically increasing absolute IDX
+
+            chainids = np.zeros_like(idx.squeeze().cpu().numpy())
+            for i, b in enumerate(breaks):
+                chainids[b:] = i+1
+            chainids = torch.from_numpy(chainids).to(device=idx.device)
+
             for chid in torch.unique(chainids):
                 is_chid = chainids==chid
                 cur_cyclize = cyclize*is_chid

--- a/rfdiffusion/util_module.py
+++ b/rfdiffusion/util_module.py
@@ -111,15 +111,14 @@ def get_seqsep(idx, cyclic=None):
     neigh[neigh > 1] = 0.0 # if bonded -- 1.0 / else 0.0
     neigh = sign * neigh
 
-    # add cyclic edges
-    breaks = find_breaks(idx.squeeze().cpu().numpy())
-    chainids = np.zeros_like(idx.squeeze().cpu().numpy())
-    for i, b in enumerate(breaks):
-        chainids[b:] = i+1
-    chainids = torch.from_numpy(chainids).to(device=idx.device)
-
     # add cyclic edges with multiple chains
     if (cyclic is not None):
+        # add cyclic edges
+        breaks = find_breaks(idx.squeeze().cpu().numpy())
+        chainids = np.zeros_like(idx.squeeze().cpu().numpy())
+        for i, b in enumerate(breaks):
+            chainids[b:] = i+1
+        chainids = torch.from_numpy(chainids).to(device=idx.device)
         for chid in torch.unique(chainids):
             is_chid = chainids==chid
             cur_cyclic = cyclic*is_chid


### PR DESCRIPTION
ae036e30c6 added code for macrocyclic peptides, which includes finding sequence breaks. But this break-finding is performed even when it isn't used. It is implemented with numpy and forces a device-host transfer.

This moves it below the conditional that actually uses the break finding. This results in noticeable performance gains.